### PR TITLE
Pollenating insects : avoid memory errors

### DIFF
--- a/databoard/specific/problems/pollenating_insects.py
+++ b/databoard/specific/problems/pollenating_insects.py
@@ -26,7 +26,7 @@ test_ratio = 0.5
 # and updates its parameters using each mini-batch.
 # Note that `batch_size` is controlled by the user, it is specified in `Classifier`
 # whereas `chunk_size` is constrolled by the backend.
-chunk_size = 1024
+chunk_size = 256
 n_img_load_jobs = 8
 # Due to memory constraints, it is not possible to predict the whole test data at 
 # once, so the predictions are also done using mini-batches.
@@ -34,7 +34,7 @@ n_img_load_jobs = 8
 # test time is controlled by `test_batch_size`, and it is set by the backend, not
 # the user. Because there is no backprop in test time, `test_batch_size` can typically
 # be larger than the one used in training.
-test_batch_size = 256
+test_batch_size = 16 
 prediction_labels = range(0, 18)
 
 # folder containing images to train or test on

--- a/problems/pollenating_insects/starting_kit/user_test_submission.py
+++ b/problems/pollenating_insects/starting_kit/user_test_submission.py
@@ -18,9 +18,9 @@ from batch_classifier_workflow import test_submission
 from batch_classifier_workflow import ArrayContainer
 
 attrs = {
-    'chunk_size': 1024,
+    'chunk_size': 256,
     'n_jobs': 8,
-    'test_batch_size': 256,
+    'test_batch_size': 16,
     'folder': 'imgs',
     'n_classes': 18
 }


### PR DESCRIPTION
 Decrease test_batch_size and chunk_size to avoid memory errors. 

- Decreasing chunk_size seems to prevent from memory leak, but the problem still needs to be solved : CPU memory usage is increasing with time.
- Decreasing test_batch_size prevents from out of memory errors of big models like resnets.