### PR TITLE
It seems submission deletion did not work when similarity was already…

### DIFF
--- a/databoard/model.py
+++ b/databoard/model.py
@@ -1851,13 +1851,15 @@ class SubmissionSimilarity(db.Model):
         db.Integer, db.ForeignKey('submissions.id'))
     source_submission = db.relationship(
         'Submission', primaryjoin=(
-            'SubmissionSimilarity.source_submission_id == Submission.id'))
+            'SubmissionSimilarity.source_submission_id == Submission.id'),
+        backref=db.backref('sources', cascade='all, delete-orphan'))
 
     target_submission_id = db.Column(
         db.Integer, db.ForeignKey('submissions.id'))
     target_submission = db.relationship(
         'Submission', primaryjoin=(
-            'SubmissionSimilarity.target_submission_id == Submission.id'))
+            'SubmissionSimilarity.target_submission_id == Submission.id'),
+        backref=db.backref('targets', cascade='all, delete-orphan'))
 
     def __repr__(self):
         repr = 'type={}, user={}, source={}, target={}, similarity={}, timestamp={}'.format(


### PR DESCRIPTION
… in place (somebody gave credits) because there was no backref/cascade. So we couldn't force add a problem (which deletes submission).