### PR TITLE
make the deployment directory before rsyncing the fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -44,6 +44,7 @@ def deploy_locally():
 
     os.system('rm -rf ' + config.local_test_deployment_path)
     os.makedirs(config.local_test_deployment_path)
+    os.makedirs(config.deployment_path)
     os.system('rsync -rultv fabfile.py ' + config.deployment_path)
     os.makedirs(config.ramp_kits_path)
     os.makedirs(config.ramp_data_path)


### PR DESCRIPTION
because rsync of fabfile.py in deploy_locally fails if deployment_path does not exist yet