### PR TITLE
Replace Fabric with Invoke as CLI tool

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -27,7 +27,7 @@ def approve_user(u):
 
 
 def serve(port=None):
-    from databoard import app, views
+    from databoard import app
 
     if port is None:
         port = app.config.get('RAMP_SERVER_PORT')
@@ -37,7 +37,8 @@ def serve(port=None):
         port=server_port,
         use_reloader=False,
         host='0.0.0.0',
-        processes=1000)
+        processes=1000,
+        threaded=False)
 
 
 def profile(port=None, profiling_file='profiler.log'):

--- a/tasks.py
+++ b/tasks.py
@@ -27,7 +27,7 @@ def approve_user(c, user):
 
 @task
 def serve(c, port=None):
-    from databoard import app, views
+    from databoard import app
 
     if port is None:
         port = app.config.get('RAMP_SERVER_PORT')
@@ -37,7 +37,8 @@ def serve(c, port=None):
         port=server_port,
         use_reloader=False,
         host='0.0.0.0',
-        processes=1000)
+        processes=1000,
+        threaded=False)
 
 
 @task


### PR DESCRIPTION
`Fabric` which has been used as a CLI tool is not well supported by Python3.
But it was built on top of `Invoke`, a CLI lib that creates tasks like `make`.

In this PR, I ported the existing methods from `fabfile.py` into `tasks.py`, the file discovered by `Invoke`.
To use, install `invoke` first: `pip install invoke`.

Various commands:
- list the available `inv --list`
- help on a task `inv -h <task_name>`

Another advantage is the support for actual flag values `True`|`False` and the automated detection of argument name and replacement with the short args:   
e.g. the task defined by the method `func(user)` can be called with any of the following commands
- `inv func --user <username>`
- `inv func --user=<username>`
- `inv func -u <username>`

Doc can be found [here](http://docs.pyinvoke.org/en/1.2/)