### PR TITLE
[WIP] ENH: improve makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,7 @@ install:
     - conda env create python=$PYTHON_VERSION -f environment.yml
     - conda env create python=$PYTHON_VERSION -f ci_tools/environment_iris_kit.yml
     - source activate testenv
-    - cd databoard
-    - pip install .
-    - cd ..
-    # install ramp-engine
-    - cd ramp-engine
-    - pip install .
-    - cd ..
-    # install ramp-database
-    - cd ramp-database
-    - pip install .
-    - cd ..
+    - make install
 script:
     - bash ci_tools/travis/test_ramp_board.sh
     - bash ci_tools/travis/test_ramp_engine.sh

--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,16 @@ clean: clean-ctags
 test-all:
     pytest -vsl
 
-test: test-all
+test: test-db test-frontend test-engine
 
 test-db:
-    pytest -vsl ramp-database/
+	pytest ramp-database/rampdb
 
 test-engine:
-    pytest -vsl ramp-engine/
+	pytest ramp-engine/rampbkd
 
 test-frontend:
-    pytest -vsl databoard/
+	pytest databoard/databoard
 
 trailing-spaces:
 	find . -type f -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ clean: clean-ctags
 	find . -type f -name '*.pyc' | xargs rm -f
 	find . -type d -name '__pycache__' | xargs rm -rf
 
-test-all:
-    pytest -vsl
+install:
+	cd databoard && pip install . && cd ..
+	cd ramp-database && pip install . && cd ..
+	cd ramp-engine && pip install . && cd ..
 
 test: test-db test-frontend test-engine
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean-ctags:
 clean: clean-ctags
 	rm -rf .pytest_cache
 	find . -type f -name '*.pyc' | xargs rm -f
-    find . -type d -name '__pycache__' | xargs rm -f
+	find . -type d -name '__pycache__' | xargs rm -rf
 
 test-all:
     pytest -vsl
@@ -27,7 +27,7 @@ test-frontend:
     pytest -vsl databoard/
 
 trailing-spaces:
-	find databoard -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
+	find . -type f -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
 
 ctags:
 	# make tags for symbol based navigation in emacs and vim

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Testing
 All modules can be tested with [`pytest`][pytest]
 
 ```bash
-pytest <module>
+make test
 ```
 
 Note that testing requires a database to be [setup and running][dbsetup].

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
-env =
-    DATABOARD_STAGE=TESTING
+env = DATABOARD_STAGE=TESTING
+addopts = -vsl
+testpaths =
+    databoard/databoard/tests
+    ramp-engine/rampbkd/tests
+    ramp-database/rampdb/tests


### PR DESCRIPTION
The old tests were using fab: 

```
test:
	# nosetests databoard/tests
	fab deploy_locally
	fab test_problem:iris,kegl
	fab test_problem:boston_housing,kegl
	fab test_keywords
	fab test_make_event_admin
	fab send_password_mail:kegl,bla
	echo 'name,password\nkegl,bla' > pwds.csv
	fab send_password_mails:pwds.csv
	rm -rf pwds.csv


test-all: test
	# nosetests databoard/tests
	fab deploy_locally
	fab test_problem:iris,kegl
	fab test_problem:boston_housing,kegl
	fab test_keywords
	fab test_make_event_admin
	fab test_problem:titanic,kegl
	fab test_problem:epidemium2_cancer_mortality,kegl
	fab test_problem:HEP_detector_anomalies,kegl
	fab test_problem:drug_spectra,kegl
	fab test_problem:air_passengers,kegl
	fab test_problem:HEP_tracking,kegl
	fab test_problem:MNIST,kegl

test-heavy:
	fab deploy_locally
	fab test_problem:el_nino,kegl
	fab test_problem:sea_ice,kegl
```
We might want to keep some of this database generation and test in the make file.
Maybe simply change `fab` => `invoke`.

Comments welcome.