### PR TITLE
[MRG] Remove psycopg2-binary dependency

### DIFF
--- a/ramp-engine/requirements.txt
+++ b/ramp-engine/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 pyyaml
 sqlalchemy
-psycopg2-binary
+psycopg2

--- a/ramp-engine/setup.py
+++ b/ramp-engine/setup.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             'numpy',
             'pyyaml',
             'sqlalchemy',
-            'psycopg2-binary'],
+            'psycopg2'],
         platforms='any',
         packages=find_packages(),
         entry_points={


### PR DESCRIPTION
Not very useful since requirements are going to be rewritten but just seeing both `psycopg2` and `psycopg2-binary` installed in the logs made me do this PR.