### PR TITLE
EHN/TST: add CLI for RAMP worker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-log_cli=true
-log_level=info
-log_format= %(levelname)s %(name)s %(message)s
-log_date_format=%Y-%m-%d %H:%M:%S

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli=true
+log_level=info
+log_format= %(levelname)s %(name)s %(message)s
+log_date_format=%Y-%m-%d %H:%M:%S

--- a/ramp-engine/rampbkd/base.py
+++ b/ramp-engine/rampbkd/base.py
@@ -78,6 +78,19 @@ class BaseWorker(six.with_metaclass(ABCMeta)):
                              'launch_submission() and then try again to '
                              'collect the results.')
 
+    def launch(self):
+        """Launch a standalone RAMP worker.
+
+        You can use this method when you want to use a worker without using
+        the RAMP dispatcher.
+        """
+        self.setup()
+        self.launch_submission()
+        # collecting the results will block the process until the submission
+        # is processed
+        self.collect_results()
+        self.teardown()
+
     def __str__(self):
         msg = ('{worker_name}({submission_name}): status="{status}"'
                .format(worker_name=self.__class__.__name__,

--- a/ramp-engine/rampbkd/cli.py
+++ b/ramp-engine/rampbkd/cli.py
@@ -62,7 +62,6 @@ def worker(config, worker_type, submission, verbose):
     config = read_config(config)
     worker_params = generate_worker_config(config)
     work = globals()[worker_type](worker_params, submission)
-    click.echo(work)
     work.launch()
 
 

--- a/ramp-engine/rampbkd/cli.py
+++ b/ramp-engine/rampbkd/cli.py
@@ -49,6 +49,11 @@ def dispatcher(config, worker_type, n_worker, hunger_policy, verbose):
 @click.option('--submission', help='The submission name')
 @click.option('-v', '--verbose', is_flag=True)
 def worker(config, worker_type, submission, verbose):
+    """Launch a standalone RAMP worker.
+
+    The RAMP worker is in charger of processing a single submission by
+    specifying the different locations (kit, data, logs, predictions)
+    """
     if verbose:
         logging.basicConfig(format='%(levelname)s %(name)s %(message)s',
                             level=logging.DEBUG)

--- a/ramp-engine/rampbkd/cli.py
+++ b/ramp-engine/rampbkd/cli.py
@@ -3,6 +3,7 @@ import logging
 import click
 
 from ramputils import read_config
+from ramputils import generate_worker_config
 
 from rampbkd.dispatcher import Dispatcher
 from rampbkd.dispatcher import CondaEnvWorker
@@ -17,7 +18,7 @@ def main():
 @main.command()
 @click.option("--config", default='config.yml',
               help='Configuration file in YAML format')
-@click.option('--worker', default='CondaEnvWorker',
+@click.option('--worker-type', default='CondaEnvWorker',
               help='Type of worker to use')
 @click.option('--n-worker', default=-1,
               help='Number of worker to start in parallel')
@@ -25,7 +26,7 @@ def main():
               help='Policy to apply in case that there is no anymore workers'
               'to be processed')
 @click.option('-v', '--verbose', is_flag=True)
-def dispatcher(config, worker, n_worker, hunger_policy, verbose):
+def dispatcher(config, worker_type, n_worker, hunger_policy, verbose):
     """Launch the RAMP dispatcher.
 
     The RAMP dispatcher is in charge of starting RAMP workers, collecting
@@ -35,9 +36,27 @@ def dispatcher(config, worker, n_worker, hunger_policy, verbose):
         logging.basicConfig(format='%(levelname)s %(name)s %(message)s',
                             level=logging.DEBUG)
     config = read_config(config)
-    disp = Dispatcher(config=config, worker=globals()[worker],
+    disp = Dispatcher(config=config, worker=globals()[worker_type],
                       n_worker=n_worker, hunger_policy=hunger_policy)
     disp.launch()
+
+
+@main.command()
+@click.option("--config", default='config.yml',
+              help='Configuration file in YAML format')
+@click.option('--worker-type', default='CondaEnvWorker',
+              help='Type of worker to use')
+@click.option('--submission', help='The submission name')
+@click.option('-v', '--verbose', is_flag=True)
+def worker(config, worker_type, submission, verbose):
+    if verbose:
+        logging.basicConfig(format='%(levelname)s %(name)s %(message)s',
+                            level=logging.DEBUG)
+    config = read_config(config)
+    worker_params = generate_worker_config(config)
+    work = globals()[worker_type](worker_params, submission)
+    click.echo(work)
+    work.launch()
 
 
 def start():

--- a/ramp-engine/rampbkd/tests/test_cli.py
+++ b/ramp-engine/rampbkd/tests/test_cli.py
@@ -36,6 +36,5 @@ def test_worker():
     result = runner.invoke(main, ["worker",
                                   "--config", path_config_example(),
                                   "--worker-type", 'CondaEnvWorker',
-                                  "--submission", "starting_kit",
-                                  "--verbose"])
+                                  "--submission", "starting_kit"])
     assert result.exit_code == 0, result.output

--- a/ramp-engine/rampbkd/tests/test_cli.py
+++ b/ramp-engine/rampbkd/tests/test_cli.py
@@ -1,5 +1,4 @@
 import shutil
-import subprocess
 
 from click.testing import CliRunner
 
@@ -29,5 +28,15 @@ def test_dispatcher():
     runner = CliRunner()
     result = runner.invoke(main, ["dispatcher",
                                   "--config", path_config_example(),
+                                  "--verbose"])
+    assert result.exit_code == 0, result.output
+
+
+def test_worker():
+    runner = CliRunner()
+    result = runner.invoke(main, ["worker",
+                                  "--config", path_config_example(),
+                                  "--worker-type", 'CondaEnvWorker',
+                                  "--submission", "starting_kit",
                                   "--verbose"])
     assert result.exit_code == 0, result.output

--- a/ramp-engine/rampbkd/tests/test_conda_worker.py
+++ b/ramp-engine/rampbkd/tests/test_conda_worker.py
@@ -66,6 +66,23 @@ def _remove_directory(worker):
 
 
 @pytest.mark.parametrize("submission", ('starting_kit', 'random_forest_10_10'))
+def test_conda_worker_launch(submission, get_conda_worker):
+    worker = get_conda_worker(submission)
+    try:
+        worker.launch()
+        # check that teardown removed the predictions
+        output_training_dir = os.path.join(worker.config['kit_dir'],
+                                           'submissions',
+                                           worker.submission,
+                                           'training_output')
+        assert not os.path.exists(output_training_dir), \
+            "teardown() failed to remove the predictions"
+    finally:
+        # remove all directories that we potentially created
+        _remove_directory(worker)
+
+
+@pytest.mark.parametrize("submission", ('starting_kit', 'random_forest_10_10'))
 def test_conda_worker(submission, get_conda_worker):
     worker = get_conda_worker(submission)
     try:


### PR DESCRIPTION
This PR add a `launch` method to the RAMP worker base class.
It allows using a RAMP worker as a standalone worker.
It is equivalent to calling `ramp_test_submission` with a setup and a teardown.