### PR TITLE
EHN: add -h as help command

### DIFF
--- a/ramp-database/rampdb/cli.py
+++ b/ramp-database/rampdb/cli.py
@@ -13,8 +13,10 @@ from .tools import submission as submission_module
 from .tools import team as team_module
 from .tools import user as user_module
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-@click.group()
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def main():
     """Command-line to interact directly with the database."""
     pass

--- a/ramp-engine/rampbkd/cli.py
+++ b/ramp-engine/rampbkd/cli.py
@@ -7,8 +7,10 @@ from ramputils import read_config
 from rampbkd.dispatcher import Dispatcher
 from rampbkd.dispatcher import CondaEnvWorker
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-@click.group()
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def main():
     """Command-line to launch engine to process RAMP submission."""
     pass

--- a/ramp-frontend/frontend/cli.py
+++ b/ramp-frontend/frontend/cli.py
@@ -5,8 +5,10 @@ from ramputils import read_config
 
 from . import create_app
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-@click.group()
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def main():
     pass
 

--- a/ramp-utils/ramputils/cli.py
+++ b/ramp-utils/ramputils/cli.py
@@ -1,10 +1,11 @@
 import click
 
-from ramputils import generate_ramp_config
 from ramputils import deploy
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-@click.group()
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def main():
     pass
 


### PR DESCRIPTION
Add by `-h` and `--help` as default command to access help of the command and subcommand.