### PR TITLE
EHN: allow for more granularity option when deploying a RAMP event

### DIFF
--- a/ramp-database/rampdb/testing.py
+++ b/ramp-database/rampdb/testing.py
@@ -92,7 +92,7 @@ def _delete_line_from_file(f_name, line_to_delete):
         f.truncate()
 
 
-def setup_ramp_kits_ramp_data(config, problem_name):
+def setup_ramp_kits_ramp_data(config, problem_name, force=False):
     """Clone ramp-kits and ramp-data repository and setup it up.
 
     Parameters
@@ -101,15 +101,36 @@ def setup_ramp_kits_ramp_data(config, problem_name):
         Configuration file containing all ramp information.
     problem_name : str
         The name of the problem.
+    force : bool, default is False
+        Whether or not to overwrite the RAMP kit and data repositories if they
+        already exists.
     """
     ramp_config = generate_ramp_config(config)
     problem_kits_path = os.path.join(ramp_config['ramp_kits_dir'],
                                      problem_name)
+    if not os.path.exists(ramp_config['ramp_kits_dir']):
+        os.makedirs(ramp_config['ramp_kits_dir'])
+    if os.path.exists(problem_kits_path):
+        if not force:
+            raise ValueError(
+                'The RAMP kit repository was previously cloned. To replace '
+                'it, you need to set "force=True".'
+            )
+        shutil.rmtree(problem_kits_path, ignore_errors=True)
     ramp_kits_url = 'https://github.com/ramp-kits/{}.git'.format(problem_name)
     Repo.clone_from(ramp_kits_url, problem_kits_path)
 
     problem_data_path = os.path.join(ramp_config['ramp_data_dir'],
                                      problem_name)
+    if not os.path.exists(ramp_config['ramp_data_dir']):
+        os.makedirs(ramp_config['ramp_data_dir'])
+    if os.path.exists(problem_data_path):
+        if not force:
+            raise ValueError(
+                'The RAMP data repository was previously cloned. To replace '
+                'it, you need to set "force=True".'
+            )
+        shutil.rmtree(problem_data_path, ignore_errors=True)
     ramp_data_url = 'https://github.com/ramp-data/{}.git'.format(problem_name)
     Repo.clone_from(ramp_data_url, problem_data_path)
 

--- a/ramp-database/rampdb/tests/test_testing.py
+++ b/ramp-database/rampdb/tests/test_testing.py
@@ -1,9 +1,11 @@
+import os
 import shutil
 
 import pytest
 from git.exc import GitCommandError
 
 from ramputils import read_config
+from ramputils import generate_ramp_config
 from ramputils.testing import path_config_example
 
 from rampdb.utils import setup_db
@@ -20,6 +22,7 @@ from rampdb.testing import create_test_db
 from rampdb.testing import add_events
 from rampdb.testing import add_users
 from rampdb.testing import add_problems
+from rampdb.testing import setup_ramp_kits_ramp_data
 from rampdb.testing import sign_up_teams_to_events
 from rampdb.testing import submit_all_starting_kits
 
@@ -44,6 +47,19 @@ def session_scope_function(config):
         shutil.rmtree(config['ramp']['deployment_dir'], ignore_errors=True)
         db, _ = setup_db(config['sqlalchemy'])
         Model.metadata.drop_all(db)
+
+
+def test_ramp_kits_ramp_data(session_scope_function, config):
+    ramp_config = generate_ramp_config(config)
+    setup_ramp_kits_ramp_data(config, 'iris')
+    msg_err = 'The RAMP kit repository was previously cloned.'
+    with pytest.raises(ValueError, match=msg_err):
+        setup_ramp_kits_ramp_data(config, 'iris')
+    shutil.rmtree(os.path.join(ramp_config['ramp_kits_dir'], 'iris'))
+    msg_err = 'The RAMP data repository was previously cloned.'
+    with pytest.raises(ValueError, match=msg_err):
+        setup_ramp_kits_ramp_data(config, 'iris')
+    setup_ramp_kits_ramp_data(config, 'iris', force=True)
 
 
 def test_add_users(session_scope_function):

--- a/ramp-database/rampdb/tests/test_testing.py
+++ b/ramp-database/rampdb/tests/test_testing.py
@@ -78,8 +78,9 @@ def test_add_problems(session_scope_function, config):
     for problem in problems:
         assert problem.name in ('iris', 'boston_housing')
     # trying to add twice the same problem will raise a git error since the
-    #  repositories already exist.
-    with pytest.raises(GitCommandError):
+    # repositories already exist.
+    msg_err = 'The RAMP kit repository was previously cloned.'
+    with pytest.raises(ValueError, match=msg_err):
         add_problems(session_scope_function, config)
 
 

--- a/ramp-utils/ramputils/cli.py
+++ b/ramp-utils/ramputils/cli.py
@@ -12,8 +12,14 @@ def main():
 @main.command()
 @click.option("--config", default='config.yml',
               help='Configuration file in YAML format')
-def deploy_ramp_event(config):
-    deploy.deploy_ramp_event(config)
+@click.option("--cloning/--no-cloning", default=True,
+              help='Whether or not to clone the RAMP kit and data '
+              'repositories.')
+@click.option('--force', is_flag=True,
+              help='Whether or not to potentially overwrite the '
+              'repositories, problem and event in the database.')
+def deploy_ramp_event(config, cloning, force):
+    deploy.deploy_ramp_event(config, cloning, force)
 
 
 def start():

--- a/ramp-utils/ramputils/deploy.py
+++ b/ramp-utils/ramputils/deploy.py
@@ -51,11 +51,12 @@ def deploy_ramp_event(config, setup_ramp_repo=True, force=False):
                     'to the kit or to the data is different. You need to set'
                     '"force=True" if you want to overwrite these parameters.'
                 )
-            setup_ramp_kits_ramp_data(config, ramp_config['event'])
+            if setup_ramp_repo:
+                setup_ramp_kits_ramp_data(config, ramp_config['event'], force)
             add_problem(session, ramp_config['event'],
                         ramp_config['ramp_kits_dir'],
                         ramp_config['ramp_data_dir'],
-                        force=True)
+                        force)
 
         if not os.path.exists(ramp_config['ramp_submissions_dir']):
             os.makedirs(ramp_config['ramp_submissions_dir'])

--- a/ramp-utils/ramputils/deploy.py
+++ b/ramp-utils/ramputils/deploy.py
@@ -26,7 +26,8 @@ def deploy_ramp_event(config, setup_ramp_repo=True, force=False):
     setup_ramp_repo : bool, default is True
         Whether or not to setup the RAMP kit and data repositories.
     force : bool, default is False
-        Whether or not to overwrite
+        Whether or not to potentially overwrite the repositories, problem and
+        event in the database.
     """
     config = read_config(config)
     database_config = config['sqlalchemy']

--- a/ramp-utils/ramputils/deploy.py
+++ b/ramp-utils/ramputils/deploy.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from rampdb.testing import setup_files_extension_type
 from rampdb.testing import setup_ramp_kits_ramp_data
@@ -11,44 +12,57 @@ from .config_parser import read_config
 from .ramp import generate_ramp_config
 
 
-def deploy_ramp_event(config):
+def deploy_ramp_event(config, setup_ramp_repo=True, force=False):
     """Deploy a RAMP event using a configuration file.
 
-    This utility will:
-
-    * create and setup the database;
-    * clone the the kit and data.
+    This utility is in charge of creating the kit and data repository for a
+    given RAMP event. It will also setup the database.
 
     Parameters
     ----------
     config : str
         The path to the configuration file containing all information necessary
         to deploy a RAMP event.
+    setup_ramp_repo : bool, default is True
+        Whether or not to setup the RAMP kit and data repositories.
+    force : bool, default is False
+        Whether or not to overwrite
     """
     config = read_config(config)
     database_config = config['sqlalchemy']
     ramp_config = generate_ramp_config(config)
 
-    def _create_dir(directory):
-        if not os.path.exists(directory):
-            os.makedirs(directory)
-
-    _create_dir(ramp_config['ramp_kits_dir'])
-    _create_dir(ramp_config['ramp_data_dir'])
-    _create_dir(ramp_config['ramp_submissions_dir'])
-
     with session_scope(database_config) as session:
         setup_files_extension_type(session)
-        # check if the problem was already created previously
-        if get_problem(session, ramp_config['event']) is None:
-            setup_ramp_kits_ramp_data(config, ramp_config['event'])
+        if setup_ramp_repo:
+            setup_ramp_kits_ramp_data(config, ramp_config['event'], force)
+        # check if the repository exists
+        problem = get_problem(session, ramp_config['event'])
+        if problem is None:
             add_problem(session, ramp_config['event'],
                         ramp_config['ramp_kits_dir'],
                         ramp_config['ramp_data_dir'])
+        else:
+            if ((ramp_config['ramp_kits_dir'] != problem.path_ramp_kits or
+                 ramp_config['ramp_data_dir'] != problem.path_ramp_data) and
+                    not force):
+                raise ValueError(
+                    'The RAMP problem already exists in the database. The path'
+                    'to the kit or to the data is different. You need to set'
+                    '"force=True" if you want to overwrite these parameters.'
+                )
+            setup_ramp_kits_ramp_data(config, ramp_config['event'])
+            add_problem(session, ramp_config['event'],
+                        ramp_config['ramp_kits_dir'],
+                        ramp_config['ramp_data_dir'],
+                        force=True)
+
+        if not os.path.exists(ramp_config['ramp_submissions_dir']):
+            os.makedirs(ramp_config['ramp_submissions_dir'])
         add_event(session, ramp_config['event'],
                   ramp_config['event_name'],
                   ramp_config['event_title'],
                   ramp_config['sandbox_name'],
                   ramp_config['ramp_submissions_dir'],
                   ramp_config['event_is_public'],
-                  False)
+                  force)

--- a/ramp-utils/ramputils/tests/test_cli.py
+++ b/ramp-utils/ramputils/tests/test_cli.py
@@ -11,10 +11,10 @@ from ramputils.testing import path_config_example
 from ramputils.cli import main
 
 
-def teardown_module(module):
+def teardown_function(function):
     config = read_config(path_config_example())
     shutil.rmtree(config['ramp']['deployment_dir'], ignore_errors=True)
-    db, Session = setup_db(config['sqlalchemy'])
+    db, _ = setup_db(config['sqlalchemy'])
     Model.metadata.drop_all(db)
 
 
@@ -22,4 +22,8 @@ def test_deploy_ramp_event():
     runner = CliRunner()
     result = runner.invoke(main, ['deploy-ramp-event',
                                   '--config', path_config_example()])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
+    result = runner.invoke(main, ['deploy-ramp-event',
+                                  '--config', path_config_example(),
+                                  '--force'])
+    assert result.exit_code == 0, result.output

--- a/ramp-utils/ramputils/tests/test_deploy.py
+++ b/ramp-utils/ramputils/tests/test_deploy.py
@@ -10,6 +10,8 @@ from rampdb.tools.submission import submit_starting_kits
 from rampdb.utils import session_scope
 from rampdb.utils import setup_db
 
+from rampdb.tools.event import get_problem
+
 from rampbkd.local import CondaEnvWorker
 from rampbkd.dispatcher import Dispatcher
 
@@ -33,6 +35,30 @@ def session_scope_function(config):
         shutil.rmtree(config['ramp']['deployment_dir'], ignore_errors=True)
         db, _ = setup_db(config['sqlalchemy'])
         Model.metadata.drop_all(db)
+
+
+def test_deploy_ramp_event_options(session_scope_function):
+    config_file = path_config_example()
+    config = read_config(config_file)
+    ramp_config = generate_ramp_config(config_file)
+    deploy_ramp_event(config_file)
+    # deploy again by forcing the deployment
+    deploy_ramp_event(config_file, force=True)
+    # do not deploy the kit to trigger the error in the problem with we don't
+    # force the deployment
+    msg_err = 'The RAMP problem already exists in the database.'
+    with pytest.raises(ValueError, match=msg_err):
+        with session_scope(config['sqlalchemy']) as session:
+            problem = get_problem(session, 'iris')
+            problem.path_ramp_kits = problem.path_ramp_kits + '_xxx'
+            session.commit()
+            deploy_ramp_event(config_file, setup_ramp_repo=False, force=False)
+
+            problem = get_problem(session, 'iris')
+            problem.path_ramp_kits = ramp_config['ramp_kits_dir']
+            problem.path_ramp_data = problem.path_ramp_data + '_xxx'
+            session.commit()
+            deploy_ramp_event(config_file, setup_ramp_repo=False, force=False)
 
 
 def test_deploy_ramp_event(session_scope_function):


### PR DESCRIPTION
This PR allows:

* avoid cloning repositories (kit + data)
* for cloning repositories (kit + data)
* force the event and problem in the database