### PR TITLE
DOC: add basic documentation on the Workers

### DIFF
--- a/doc/create_ramp_event.rst
+++ b/doc/create_ramp_event.rst
@@ -1,6 +1,8 @@
 Set up a new RAMP event
 =======================
 
+.. _deploy-ramp-event:
+
 Deploy a specific RAMP event
 ----------------------------
 

--- a/doc/design_your_own_workers.rst
+++ b/doc/design_your_own_workers.rst
@@ -1,2 +1,0 @@
-Design your own RAMP worker
-===========================

--- a/doc/note_on_workers.rst
+++ b/doc/note_on_workers.rst
@@ -1,2 +1,0 @@
-Notes regarding the available RAMP workers
-==========================================

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -11,5 +11,4 @@ User Guide
 
    setup_server.rst
    create_ramp_event.rst
-   note_on_workers.rst
-   design_your_own_workers.rst
+   workers.rst

--- a/doc/workers.rst
+++ b/doc/workers.rst
@@ -1,0 +1,21 @@
+Notes regarding the RAMP workers
+================================
+
+The RAMP "worker" is the object responsible of actually running (training and
+evaluating) a submission and returning back the results (predictions and
+scores).
+The workers are typically launched from a loop set up for a specific event on
+the server. The worker can then run the submission either locally on the server
+or on a remote machine.
+
+The type of worker used in a certain event is specified in the ``worker``
+section of the yml configuration file, using the ``worker_type`` key (see
+:ref:`deploy-ramp-event`). Additional keys can be required depending on
+the worker type.
+
+Available workers:
+
+* The :class:`ramp_engine.local.CondaEnvWorker` will run the submission in
+  a specific isolated conda environment. This worker is specified as
+  ``worker_type: conda`` and requires an additional key ``conda_env``
+  specifying the name of the conda environment.


### PR DESCRIPTION
Added a basic description of the workers (so I can add a section there as well in the AWS PR).

Also merged to two existing files into one since there is not yet much content.