### PR TITLE
Add a --force option when running a standalone worker

### DIFF
--- a/ramp-engine/ramp_engine/cli.py
+++ b/ramp-engine/ramp_engine/cli.py
@@ -61,7 +61,9 @@ def dispatcher(config, event_config, n_worker, hunger_policy, verbose):
               help='Configuration file in YAML format')
 @click.option('--submission', help='The submission name')
 @click.option('-v', '--verbose', is_flag=True)
-def worker(config, submission, verbose):
+@click.option('--force', is_flag=True,
+              help="Overwrite exisiting predictions for this submission")
+def worker(config, submission, verbose, force):
     """Launch a standalone RAMP worker.
 
     The RAMP worker is in charger of processing a single submission by
@@ -79,6 +81,7 @@ def worker(config, submission, verbose):
     config = read_config(config)
     worker_params = generate_worker_config(config)
     worker_type = available_workers[worker_params['worker_type']]
+    worker_params['force'] = force
     worker = worker_type(worker_params, submission)
     worker.launch()
 

--- a/ramp-engine/ramp_engine/local.py
+++ b/ramp-engine/ramp_engine/local.py
@@ -28,6 +28,7 @@ class CondaEnvWorker(BaseWorker):
           submission will be stored;
         * `predictions_dir`: path to the directory where the
           predictions of the submission will be stored.
+        - `force`: overwrite results from previous runs
     submission : str
         Name of the RAMP submission to be handle by the worker.
 
@@ -163,6 +164,8 @@ class CondaEnvWorker(BaseWorker):
             output_training_dir = os.path.join(
                 self.config['submissions_dir'], self.submission,
                 'training_output')
+            if os.path.exists(pred_dir) and self.config['force']:
+                shutil.rmtree(pred_dir)
             shutil.copytree(output_training_dir, pred_dir)
             self.status = 'collected'
             logger.info(repr(self))


### PR DESCRIPTION
Partially addresses https://github.com/paris-saclay-cds/ramp-board/issues/165

Adds a `--force` option to `ramp-launch worker` to delete existing predictions (if any exist). Not sure if this will work fine for the database -- testing now.