### PR TITLE
Delete predict folder if it exists

### DIFF
--- a/ramp-engine/ramp_engine/local.py
+++ b/ramp-engine/ramp_engine/local.py
@@ -163,6 +163,8 @@ class CondaEnvWorker(BaseWorker):
             output_training_dir = os.path.join(
                 self.config['submissions_dir'], self.submission,
                 'training_output')
+            if os.path.exists(pred_dir):
+                shutil.rmtree(pred_dir)
             shutil.copytree(output_training_dir, pred_dir)
             self.status = 'collected'
             logger.info(repr(self))


### PR DESCRIPTION
Continues https://github.com/paris-saclay-cds/ramp-board/pull/167

Actually even if run tag a submission to be re-run as suggested in https://github.com/paris-saclay-cds/ramp-board/issues/165#issuecomment-470279119, I still get the error about an existing predict folder in https://github.com/paris-saclay-cds/ramp-board/issues/165#issue-418005998 which crashes the dispatcher.

This removes the folder with result predictions if they exist to avoid it.

cc @glemaitre 