### PR TITLE
MAINT Remove ramp_frontend/security

### DIFF
--- a/ramp-frontend/ramp_frontend/security.py
+++ b/ramp-frontend/ramp_frontend/security.py
@@ -1,5 +1,0 @@
-from itsdangerous import URLSafeTimedSerializer
-
-from ramp_frontend import app
-
-ts = URLSafeTimedSerializer(app.config["SECRET_KEY"])

--- a/ramp-utils/ramp_utils/tests/test_frontend.py
+++ b/ramp-utils/ramp_utils/tests/test_frontend.py
@@ -14,7 +14,6 @@ from ramp_utils import generate_flask_config
 def test_generate_flask_config(config):
     flask_config = generate_flask_config(config)
     expected_config = {
-        'SECRET_KEY': 'abcdefghijkl',
         'WTF_CSRF_ENABLED': True,
         'LOG_FILENAME': 'None',
         'MAX_CONTENT_LENGTH': 1073741824,

--- a/ramp-utils/ramp_utils/tests/test_frontend.py
+++ b/ramp-utils/ramp_utils/tests/test_frontend.py
@@ -14,6 +14,7 @@ from ramp_utils import generate_flask_config
 def test_generate_flask_config(config):
     flask_config = generate_flask_config(config)
     expected_config = {
+        'SECRET_KEY': 'abcdefghijkl',
         'WTF_CSRF_ENABLED': True,
         'LOG_FILENAME': 'None',
         'MAX_CONTENT_LENGTH': 1073741824,


### PR DESCRIPTION
This removes `ramp_frontend/security.py` that is never used and relies on an import `ramp_frontend.app` that is not valid.

Unless you are planning to keep this functionality?