### PR TITLE
MAINT: remove jupyter and only add nbconvet and docfix

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -12,8 +12,7 @@ The dependencies required by the RAMP bundle are the following:
 1. ``ramp-database``:
     * click
     * gitpython
-    * ipykernel
-    * jupyter
+    * nbconvert
     * numpy
     * pandas
     * psycopg2
@@ -50,11 +49,10 @@ repository::
 
 You can use ``conda`` instead of ``pip`` using the ``environment.yml`` file::
 
-    conda env update --file environment.yml
+    conda env update --file environment.yml --name <your_env>
 
-The above command updates the base environment or the environment in which you
-ran the command. If you want to keep the code to run ramp in a separate
-environment, you can also do::
+The above command updates the <your_env> environment. If you want to keep the
+code to run ramp in a separate environment, you can also do::
 
     conda env create -f environment.yml
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,8 +11,7 @@ dependencies:
   - Flask-SQLAlchemy
   - Flask-Wtf
   - gitpython
-  - ipykernel
-  - jupyter
+  - nbconvert
   - numpy
   - pandas
   - pyyaml

--- a/ramp-database/setup.py
+++ b/ramp-database/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Programming Language :: Python :: 2.7',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7']
-INSTALL_REQUIRES = ['click', 'gitpython', 'ipykernel', 'jupyter', 'numpy',
+INSTALL_REQUIRES = ['click', 'gitpython', 'nbconvert', 'numpy',
                     'pandas', 'psycopg2', 'six', 'sqlalchemy']
 EXTRAS_REQUIRE = {
     'tests': ['pytest', 'pytest-cov'],


### PR DESCRIPTION
Remove jyupyter and ipykernel from the dependency and add nbconvert only
The documentation was fixed as well to update using the environment.yml