### PR TITLE
BUG: avoid memory leak induced by backreference in scoring

### DIFF
--- a/ramp-database/ramp_database/tools/submission.py
+++ b/ramp-database/ramp_database/tools/submission.py
@@ -430,10 +430,12 @@ def get_scores(session, submission_id):
     scores : pd.DataFrame
         A pandas dataframe containing the scores of each fold.
     """
-    submission = select_submission_by_id(session, submission_id)
     results = defaultdict(list)
     index = []
-    for fold_id, cv_fold in enumerate(submission.on_cv_folds):
+    all_cv_folds = (session.query(SubmissionOnCVFold)
+                           .filter_by(submission_id=submission_id)
+                           .all())
+    for fold_id, cv_fold in enumerate(all_cv_folds):
         for step in ('train', 'valid', 'test'):
             index.append((fold_id, step))
             for score in cv_fold.scores:


### PR DESCRIPTION
closes #190 

The backreferencing from SQLAlchemy introduces a memory leak. The SubmissionOnCVFold objects are unpickling prediction and indices which are large arrays. Those not collected by the garbage collector can lead to large array to be leaked without any way to dereferencing them.

