### PR TITLE
DOC: add path information when deploying RAMP

### DIFF
--- a/doc/create_ramp_event.rst
+++ b/doc/create_ramp_event.rst
@@ -9,21 +9,22 @@ Deploy a specific RAMP event
 Now we will want to deploy a specific problem and event. We will take an
 example by deploying an ``iris`` event.
 
-First, you need to get the starting kit and the data::
+First, you need to get the starting kit and the data within the
+``ramp_deployment`` directory::
 
-    mkdir ramp-kits
-    mkdir ramp-data
-    git clone https://github.com/ramp-kits/iris ramp-kits/iris
-    git clone https://github.com/ramp-data/iris ramp-data/iris
-    cd ramp-data/iris
-    python prepare_data.py
-    cd ../..
+    ~/ramp_deployment $ mkdir ramp-kits
+    ~/ramp_deployment $ mkdir ramp-data
+    ~/ramp_deployment $ git clone https://github.com/ramp-kits/iris ramp-kits/iris
+    ~/ramp_deployment $ git clone https://github.com/ramp-data/iris ramp-data/iris
+    ~/ramp_deployment $ cd ramp-data/iris
+    ~/ramp_deployment/ramp-kits/iris $ python prepare_data.py
+    ~/ramp_deployment/ramp-kits/iris $ cd ../..
 
 Next, you need to create a configuration file for a specific event. You can
-create this with::
+create this configuration file by executing the following command line from
+the ``ramp_deployment`` folder::
 
-    ramp setup init-event --name iris_test
-
+    ~/ramp_deployment $ ramp setup init-event --name iris_test
 
 The above creates a ``events/iris_test`` directory inside the deployment
 directory, and populates it with a ``config.yml`` with the configuration
@@ -60,7 +61,13 @@ deploy-event`` do that for you.
 Launch the dispatcher to train and evaluate submissions
 -------------------------------------------------------
 
-At this stage, you can launch the RAMP dispatcher which will be in charge of
-training, evaluating submissions, and updating the database::
+At this stage, you can launch the RAMP dispatcher from the ``ramp_deployment``
+directory, which will be in charge of training, evaluating submissions, and
+updating the database::
 
-    ramp launch dispatcher --event-config events/iris_test/config.yml --hunger-policy sleep -vv
+    ~/ramp_deployment $ ramp launch dispatcher --event-config events/iris_test/config.yml --hunger-policy sleep -vv
+
+If you are running the dispatcher on a remote server, you want to launch it
+within a terminal multiplexer as ``screen`` or ``tmux``. It will allow you
+to detach the process and let it run. Refer to the documentation of ``screen``
+or ``tmux`` to use them.

--- a/doc/setup_server.rst
+++ b/doc/setup_server.rst
@@ -13,21 +13,21 @@ We advise to use ``PostgreSQL`` for managing the database. You can install
 ``PostgreSQL`` using the system packages. If you are using ``conda``, we
 advise you to install it using the following command::
 
-    conda install postgresql
+    ~ $ conda install postgresql
 
 Once ``PostgreSQL`` is installed, we initialize a Postgres database cluster::
 
-    initdb postgres_dbs
+    ~ $ initdb postgres_dbs
 
 To start the database, you need to execute the following command::
 
-    pg_ctl -D postgres_dbs -l logfile start
+    ~ $ pg_ctl -D postgres_dbs -l logfile start
 
 Once the cluster has been initialized, we need to create an admin user and
 create the database which will be used for RAMP::
 
-    createuser --pwprompt <db_user>
-    createdb --owner=<db_user> <db_name>
+    ~ $ createuser --pwprompt <db_user>
+    ~ $ createdb --owner=<db_user> <db_name>
 
 where <db_user>, <db_password> and <db_name> should be replaced with actual
 values. Those values should match with the RAMP configuration file.
@@ -38,14 +38,14 @@ Set up the RAMP deployment for kits, data, and submissions
 You need to create a directory in which you will deploy the RAMP kits, data,
 and submissions::
 
-    mkdir ramp_deployment
-    cd ramp_deployment
+    ~ $ mkdir ramp_deployment
+    ~ $ cd ramp_deployment
 
 Next, you need to create a ``config.yml`` file in the directory, which holds
 the configuration for the database and the flask server. A generic template
 can be created using::
 
-    ramp setup init
+    ~/ramp_deployment $ ramp setup init
 
 which will create a ``config.yml`` file inside the deployment directory. Now,
 you can edit this file filling in the correct database name, user name and
@@ -78,16 +78,18 @@ information.
 Create an admin user
 --------------------
 
-To operate the event, it is useful to first create an admin user::
+To operate the event, it is useful to first create an admin user. From the
+``ramp_deployment`` directory, run the following command::
 
-    ramp database add-user --login admin_user --password password --firstname firstname --lastname lastname --email admin@email.com --access-level admin
+    ~/ramp_deployment $ ramp database add-user --login admin_user --password password --firstname firstname --lastname lastname --email admin@email.com --access-level admin
 
 Launching a test instance of the  RAMP website
 ----------------------------------------------
 
-At this stage, you will be able to test the RAMP website::
+At this stage, you will be able to test the RAMP website. From the
+``ramp_deployment`` directory, run the following command::
 
-    ramp frontend test-launch
+    ~/ramp_deployment $ ramp frontend test-launch
 
 This uses the built-in server of Flask suitable for testing. To deploy it
 in a production setting, you can refer to the following sections or to the
@@ -99,11 +101,11 @@ Using Gunicorn
 If you are using a UNIX server, you can use Gunicorn as a webserver. You can
 install directly from ``conda``::
 
-    conda install gunicorn
+    ~ $ conda install gunicorn
 
 To launch the RAMP website, you can execute::
 
-    gunicorn -w 8 --bind 0.0.0.0:8080 --access-logfile ./frontend.log 'ramp_frontend.wsgi:make_app("config.yml")'
+    ~/ramp_deployment $ gunicorn -w 8 --bind 0.0.0.0:8080 --access-logfile ./frontend.log 'ramp_frontend.wsgi:make_app("config.yml")'
 
 where ``config.yml`` is the path to the configuration fle created in the
 ``ramp_deployment`` directory. To have more information about the Gunicorn


### PR DESCRIPTION
It could be easy to get confused with the different path.
I made more explicit explanations regarding the path where the different commands are run.