### PR TITLE
EHN: force user to confirm their email address

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -397,8 +397,11 @@ Authentication views
    auth.load_user
    auth.login
    auth.logout
+   auth.reset_password
+   auth.reset_with_token
    auth.sign_up
    auth.update_profile
+   auth.user_confirm_email
 
 Admin views
 ...........

--- a/ramp-database/ramp_database/model/user.py
+++ b/ramp-database/ramp_database/model/user.py
@@ -72,8 +72,14 @@ class User(Model):
         The user's first name.
     email : str
         The user's email
-    access_level : {'admin', 'user', 'asked'}
-        The user's admin level.
+    access_level : {'admin', 'user', 'asked', 'not_confirmed'}
+        The user's admin level. The possible access level are:
+
+        * 'admin' : RAMP administrator;
+        * 'user': RAMP user;
+        * 'asked': asked to be a RAMP user and confirmed via emails;
+        * 'not_confirmed': signed-up through the frontend but did not confirm
+          yet by email.
     hidden_notes : str
         Some hidden notes.
     signup_timestamp : datetime
@@ -121,9 +127,10 @@ class User(Model):
     hidden_notes = Column(String, default=None)
     bio = Column(String(1024), default=None)
     is_want_news = Column(Boolean, default=True)
-    access_level = Column(Enum(
-        'admin', 'user', 'asked', name='access_level'), default='asked')
-    # 'asked' needs approval
+    access_level = Column(
+        Enum('admin', 'user', 'asked', 'not_confirmed', name='access_level'),
+        default='asked'
+    )
     signup_timestamp = Column(DateTime, nullable=False)
 
     # Flask-Login fields

--- a/ramp-frontend/ramp_frontend/views/auth.py
+++ b/ramp-frontend/ramp_frontend/views/auth.py
@@ -322,7 +322,7 @@ def user_confirm_email(token):
         )
         body = body_formatter_user(user)
         url_approve = ('http://www.ramp.studio/sign_up/{}'
-                        .format(user.name))
+                       .format(user.name))
         body += 'Click on the link to approve the registration '
         body += 'of this user: {}'.format(url_approve)
         send_mail(admin.email, subject, body)


### PR DESCRIPTION
This PR force a user to confirm his email address:

* force user to have a real email address;
* remove from the list to approve email which has not been confirmed.