### PR TITLE
ENH Add depth parameter to setup_ramp_kit_ramp_data

### DIFF
--- a/ramp-database/ramp_database/testing.py
+++ b/ramp-database/ramp_database/testing.py
@@ -123,7 +123,8 @@ def _delete_line_from_file(f_name, line_to_delete):
         f.truncate()
 
 
-def setup_ramp_kit_ramp_data(ramp_config, problem_name, force=False):
+def setup_ramp_kit_ramp_data(ramp_config, problem_name, force=False,
+                             depth=None):
     """Clone ramp-kit and ramp-data repository and setup it up.
 
     Parameters
@@ -137,6 +138,9 @@ def setup_ramp_kit_ramp_data(ramp_config, problem_name, force=False):
     force : bool, default is False
         Whether or not to overwrite the RAMP kit and data repositories if they
         already exists.
+    depth : int, default=None
+        the depth parameter to pass to git clone. Use ``depth=1`` for a shallow
+        clone (faster).
     """
     problem_kit_path = ramp_config['ramp_kit_dir']
     if os.path.exists(problem_kit_path):
@@ -147,7 +151,10 @@ def setup_ramp_kit_ramp_data(ramp_config, problem_name, force=False):
             )
         shutil.rmtree(problem_kit_path, ignore_errors=True)
     ramp_kit_url = 'https://github.com/ramp-kits/{}.git'.format(problem_name)
-    Repo.clone_from(ramp_kit_url, problem_kit_path)
+    kwargs = {}
+    if depth is not None:
+        kwargs['depth'] = depth
+    Repo.clone_from(ramp_kit_url, problem_kit_path, **kwargs)
 
     problem_data_path = ramp_config['ramp_data_dir']
     if os.path.exists(problem_data_path):
@@ -158,7 +165,7 @@ def setup_ramp_kit_ramp_data(ramp_config, problem_name, force=False):
             )
         shutil.rmtree(problem_data_path, ignore_errors=True)
     ramp_data_url = 'https://github.com/ramp-data/{}.git'.format(problem_name)
-    Repo.clone_from(ramp_data_url, problem_data_path)
+    Repo.clone_from(ramp_data_url, problem_data_path, **kwargs)
 
     current_directory = os.getcwd()
     os.chdir(problem_data_path)
@@ -246,7 +253,7 @@ def add_problems(session):
     }
     for problem_name, ramp_config in ramp_configs.items():
         internal_ramp_config = generate_ramp_config(ramp_config)
-        setup_ramp_kit_ramp_data(internal_ramp_config, problem_name)
+        setup_ramp_kit_ramp_data(internal_ramp_config, problem_name, depth=1)
         add_problem(session, problem_name,
                     internal_ramp_config['ramp_kit_dir'],
                     internal_ramp_config['ramp_data_dir'])

--- a/ramp-database/ramp_database/tests/test_testing.py
+++ b/ramp-database/ramp_database/tests/test_testing.py
@@ -54,16 +54,16 @@ def session_scope_function(database_config, ramp_config, database_connection):
 
 def test_ramp_kit_ramp_data(session_scope_function, ramp_config):
     internal_ramp_config = generate_ramp_config(read_config(ramp_config))
-    setup_ramp_kit_ramp_data(internal_ramp_config, 'iris')
+    setup_ramp_kit_ramp_data(internal_ramp_config, 'iris', depth=1)
     msg_err = 'The RAMP kit repository was previously cloned.'
     with pytest.raises(ValueError, match=msg_err):
-        setup_ramp_kit_ramp_data(internal_ramp_config, 'iris')
+        setup_ramp_kit_ramp_data(internal_ramp_config, 'iris', depth=1)
 
     # retrieve the path to the ramp kit to remove it
     shutil.rmtree(internal_ramp_config['ramp_kit_dir'])
     msg_err = 'The RAMP data repository was previously cloned.'
     with pytest.raises(ValueError, match=msg_err):
-        setup_ramp_kit_ramp_data(internal_ramp_config, 'iris')
+        setup_ramp_kit_ramp_data(internal_ramp_config, 'iris', depth=1)
     setup_ramp_kit_ramp_data(internal_ramp_config, 'iris', force=True)
 
 

--- a/ramp-database/ramp_database/tools/tests/test_event.py
+++ b/ramp-database/ramp_database/tools/tests/test_event.py
@@ -199,7 +199,7 @@ def test_check_event(session_scope_function):
     }
     for problem_name, ramp_config in ramp_configs.items():
         internal_ramp_config = generate_ramp_config(ramp_config)
-        setup_ramp_kit_ramp_data(internal_ramp_config, problem_name)
+        setup_ramp_kit_ramp_data(internal_ramp_config, problem_name, depth=1)
         add_problem(session_scope_function, problem_name,
                     internal_ramp_config['ramp_kit_dir'],
                     internal_ramp_config['ramp_data_dir'])


### PR DESCRIPTION
Ramp starting kit repos can be somewhat large due to the history of the jupyter notebooks they contain.

This adds an optional `depth` parameter to `setup_ramp_kit_ramp_data` that is going to be passed to `git clone`. In particular, `depth=1` will make a shallow clone (used in particular in tests by default).

Not sure this matters much in practice, but tests are slow so I imagine anything helps..