### PR TITLE
FIX Use query(...).one_or_none in ramp_database._query

### DIFF
--- a/ramp-database/ramp_database/tools/_query.py
+++ b/ramp-database/ramp_database/tools/_query.py
@@ -93,7 +93,7 @@ def select_submission_by_name(session, event_name, team_name, name):
                    .filter(EventTeam.id == Submission.event_team_id)
                    .filter(Submission.name == name)
                    .order_by(Submission.submission_timestamp)
-                   .one())
+                   .one_or_none())
 
 
 def select_event_by_name(session, event_name):
@@ -158,7 +158,7 @@ def select_user_by_name(session, user_name):
     """
     if user_name is None:
         return session.query(User).all()
-    return session.query(User).filter(User.name == user_name).one()
+    return session.query(User).filter(User.name == user_name).one_or_none()
 
 
 def select_user_by_email(session, email):

--- a/ramp-database/ramp_database/tools/tests/test_query.py
+++ b/ramp-database/ramp_database/tools/tests/test_query.py
@@ -1,0 +1,88 @@
+import pytest
+import shutil
+
+from ramp_database.model import Model
+from ramp_database.model import User
+from ramp_database.model import Submission
+from ramp_utils import read_config
+from ramp_utils.testing import database_config_template
+from ramp_utils.testing import ramp_config_template
+from ramp_database.testing import create_toy_db
+from ramp_database.utils import session_scope
+from ramp_database.utils import setup_db
+from ramp_database.tools._query import (
+    select_submissions_by_state,
+    select_submission_by_name,
+    select_submission_by_id,
+    select_user_by_name,
+
+)
+
+
+def _change_state_db(session):
+    # change the state of one of the submission in the iris event
+    submission_id = 1
+    sub = (session.query(Submission)
+                  .filter(Submission.id == submission_id)
+                  .first())
+    sub.set_state('trained')
+    session.commit()
+
+
+@pytest.fixture(scope='module')
+def session_scope_module(database_connection):
+    database_config = read_config(database_config_template())
+    ramp_config = ramp_config_template()
+    try:
+        deployment_dir = create_toy_db(database_config, ramp_config)
+        with session_scope(database_config['sqlalchemy']) as session:
+            _change_state_db(session)
+            yield session
+    finally:
+        shutil.rmtree(deployment_dir, ignore_errors=True)
+        db, _ = setup_db(database_config['sqlalchemy'])
+        Model.metadata.drop_all(db)
+
+
+def test_select_submissions_by_state(session_scope_module):
+    session = session_scope_module
+
+    res = select_submissions_by_state(session, "iris_test", None)
+    assert len(res) > 1
+
+    res = select_submissions_by_state(session, "iris_test", "trained")
+    assert len(res) == 1
+
+    res = select_submissions_by_state(session, "not_existing", None)
+    assert len(res) == 0
+
+
+def test_select_submissions_by_name(session_scope_module):
+    session = session_scope_module
+
+    res = select_submission_by_name(session, "iris_test", "test_user_2",
+                                    "starting_kit")
+    assert isinstance(res, Submission)
+
+    res = select_submission_by_name(session, "unknown", "unknown", "unknown")
+    assert res is None
+
+
+def test_select_user_by_name(session_scope_module):
+    session = session_scope_module
+
+    res = select_user_by_name(session, "test_user_2")
+    assert isinstance(res, User)
+
+    res = select_user_by_name(session, "invalid")
+    assert res is None
+
+
+def test_select_submissions_by_id(session_scope_module):
+    session = session_scope_module
+
+    res = select_submission_by_id(session, 1)
+    assert isinstance(res, Submission)
+
+    res = select_submission_by_id(session, 99999)
+    assert res is None

--- a/ramp-database/ramp_database/tools/user.py
+++ b/ramp-database/ramp_database/tools/user.py
@@ -4,7 +4,6 @@ import logging
 import pandas as pd
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
 
 from ..exceptions import NameClashError
 from ..model import Team
@@ -87,23 +86,15 @@ def add_user(session, name, password, lastname, firstname, email,
     except IntegrityError as e:
         session.rollback()
         message = ''
-        try:
-            select_user_by_name(session, name)
+        if select_user_by_name(session, name) is not None:
             message += 'username is already in use'
-        except NoResultFound:
+        elif select_team_by_name(session, name) is not None:
             # We only check for team names if username is not in db
-            try:
-                select_team_by_name(session, name)
-                message += 'username is already in use as a team name'
-            except NoResultFound:
-                pass
-        try:
-            select_user_by_email(session, lower_case_email)
+            message += 'username is already in use as a team name'
+        if select_user_by_email(session, lower_case_email) is not None:
             if message:
                 message += ' and '
             message += 'email is already in use'
-        except NoResultFound:
-            pass
         if message:
             raise NameClashError(message)
         else:
@@ -340,13 +331,9 @@ def set_user_by_instance(session, user, lastname, firstname, email,
         session.commit()
     except IntegrityError as e:
         session.rollback()
-        message = ''
-        try:
-            select_user_by_email(session, user.email)
-            message += 'email is already in use'
-        except NoResultFound:
-            pass
-        if len(message) > 0:
+        if select_user_by_email(session, user.email) is not None:
+            message = 'email is already in use'
+
             logger.error(message)
             raise NameClashError(message)
         else:

--- a/ramp-frontend/ramp_frontend/views/auth.py
+++ b/ramp-frontend/ramp_frontend/views/auth.py
@@ -15,8 +15,6 @@ from flask import url_for
 
 from itsdangerous import URLSafeTimedSerializer
 
-from sqlalchemy.orm.exc import NoResultFound
-
 from ramp_database.utils import check_password
 from ramp_database.utils import hash_password
 
@@ -73,10 +71,9 @@ def login():
 
     form = LoginForm()
     if form.validate_on_submit():
-        try:
-            user = get_user_by_name_or_email(db.session,
-                                             name=form.user_name.data)
-        except NoResultFound:
+        user = get_user_by_name_or_email(db.session,
+                                         name=form.user_name.data)
+        if user is None:
             msg = 'User "{}" does not exist'.format(form.user_name.data)
             flash(msg)
             logger.info(msg)


### PR DESCRIPTION
Closes https://github.com/paris-saclay-cds/ramp-board/issues/181

Generally use `query(...).one_or_none()` instead of `query(..).one()` to avoid exceptions when no results exist in `select_submission_by_name` and `select_user_by_name`.  + some tests.