### PR TITLE
Improve database for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,8 +18,8 @@ def database_connection():
     """
     config = safe_load(open("db_engine.yml"))
     dbowner = config.get('db_owner')
-    dbcluster = config.get('db_cluster_name')
-    engine = create_engine(f'postgresql://{dbowner}:@localhost/{dbcluster}',
+
+    engine = create_engine(f'postgresql://{dbowner}:@localhost/postgres',
                            isolation_level='AUTOCOMMIT')
 
     connection = engine.connect()

--- a/db_engine.yml
+++ b/db_engine.yml
@@ -1,2 +1,2 @@
-db_owner: mtelencz # to find out your db_owner type psql -l in the terminal
+db_owner: postgres # to find out your db_owner type psql -l in the terminal
                    # and check who is the owner of your postgres database 

--- a/db_engine.yml
+++ b/db_engine.yml
@@ -1,2 +1,2 @@
-db_owner: postgres # to find out your db_owner type psql -l in the terminal
-db_cluster_name: postgres # name of the engine database you have created
+db_owner: mtelencz # to find out your db_owner type psql -l in the terminal
+                   # and check who is the owner of your postgres database 

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -23,10 +23,11 @@ that you use the ``make inplace`` option to install RAMP in developer mode.
 
 Prepare database engine
 -----------------------
-Testing RAMP require a database, you need to create a database similarly to
-:ref:`create database <set_database>`
+Testing RAMP requires a database cluster, you need to create it similarly as 
+described in :ref:`create database <set_database>` section. 
 
-In short, create the ``Postgres database cluster`` using the command::
+If you haven't done so already create the ``Postgres database cluster`` 
+using the command::
 
     ~ $ initdb postgres_dbs
 
@@ -34,25 +35,24 @@ and then start it with::
 
     ~ $ pg_ctl -D postgres_dbs -l logfile start
 
-However, RAMP tests do not know which database engine you are using for 
-your ramp development and therefore you need to inform RAMP tests about this
-To do this, open the ``db_engine.yml`` file located in the ``ramp-board`` directory. 
+Within your database cluster `postgres` database is created automatically.
+`pytest` will use it to make and then drop the test engine. But it needs
+to know who is the owner of your `postgres` database and therefore you 
+need to inform RAMP tests about this.
+To do this, open the ``db_engine.yml`` file located in the ``ramp-board`` 
+directory. 
 It should look as follows::
 
     db_owner: postgres
-    db_cluster_name: postgres
 
-You need to change <postgres> to your local settings.
+You need to change <postgres> to the owner of the `postgres` database. 
 
-``db_owner`` is the owner of your database. If you don't know who is 
-the owner of your database you can find it out by typing in your terminal::
+If you don't know who is the owner of your `postgres` database you can 
+find it out by typing in your terminal::
     
     ~ $ psql -l
 
 This command will list all of your databases along with their owners. 
-
-``db_cluster_name`` is the name of your Postgres database cluster (if you used
-commands as above your ``Postgres database cluster`` name is `'postgres_dbs'`).
 
 Test
 ----


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #304 

#### What does this implement/fix? Explain your changes.
Thanks @kegl 
you are right. The explanation was not clear enough. I now changed the docs and hardcoded the database name to postgres (which is automatically created when installing postgresql, can be used by tests and won't cause confusion). As for the db_user you need to run `psql -l` to see who is the owner of your postgres database.

This should hopefully solve the two issues you mentioned:
1) problem with knowing which `db_cluster_name` to use, and 
2) replication of user (as the idea is to always create the new tables and drop them after tests)

as for the third one: 
3) we cannot run pytest in ramp-board/ramp-database
I am not sure how to improve it. From root it should work but if you have some ideas I will be happy to implement them


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
