### PR TITLE
BUG sort cv folds ordered during queries

### DIFF
--- a/ramp-database/ramp_database/model/submission.py
+++ b/ramp-database/ramp_database/model/submission.py
@@ -408,6 +408,7 @@ class Submission(Model):
             all_cv_folds = (session.query(SubmissionOnCVFold)
                                    .filter_by(submission_id=self.id)
                                    .all())
+            all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
         for submission_on_cv_fold in all_cv_folds:
             submission_on_cv_fold.state = state
 
@@ -449,6 +450,7 @@ class Submission(Model):
             all_cv_folds = (session.query(SubmissionOnCVFold)
                                    .filter_by(submission_id=self.id)
                                    .all())
+            all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
         for submission_on_cv_fold in all_cv_folds:
             submission_on_cv_fold.set_error(error, error_msg)
 
@@ -470,6 +472,7 @@ class Submission(Model):
                 all_cv_folds = (session.query(SubmissionOnCVFold)
                                        .filter_by(submission_id=self.id)
                                        .all())
+                all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
             unit_contributivity = 1. / len(all_cv_folds)
             for submission_on_cv_fold in all_cv_folds:
                 self.contributivity += (unit_contributivity *
@@ -486,6 +489,7 @@ class Submission(Model):
             all_cv_folds = (session.query(SubmissionOnCVFold)
                                    .filter_by(submission_id=self.id)
                                    .all())
+            all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
         states = [submission_on_cv_fold.state
                   for submission_on_cv_fold in all_cv_folds]
         if all(state == 'tested' for state in states):

--- a/ramp-database/ramp_database/tools/submission.py
+++ b/ramp-database/ramp_database/tools/submission.py
@@ -110,6 +110,7 @@ def add_submission(session, event_name, team_name, submission_name,
             all_cv_folds = (session.query(SubmissionOnCVFold)
                                    .filter_by(submission_id=submission.id)
                                    .all())
+            all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
             for submission_on_cv_fold in all_cv_folds:
                 submission_on_cv_fold.reset()
         else:
@@ -391,6 +392,7 @@ def get_predictions(session, submission_id):
     all_cv_folds = (session.query(SubmissionOnCVFold)
                            .filter_by(submission_id=submission_id)
                            .all())
+    all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
     for fold_id, cv_fold in enumerate(all_cv_folds):
         results['fold'].append(fold_id)
         results['y_pred_train'].append(cv_fold.full_train_y_pred)
@@ -419,6 +421,7 @@ def get_time(session, submission_id):
                            .options(defer("full_train_y_pred"),
                                     defer("test_y_pred"))
                            .all())
+    all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
     for fold_id, cv_fold in enumerate(all_cv_folds):
         results['fold'].append(fold_id)
         for step in ('train', 'valid', 'test'):
@@ -448,6 +451,7 @@ def get_scores(session, submission_id):
                            .options(defer("full_train_y_pred"),
                                     defer("test_y_pred"))
                            .all())
+    all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
     for fold_id, cv_fold in enumerate(all_cv_folds):
         for step in ('train', 'valid', 'test'):
             index.append((fold_id, step))
@@ -637,6 +641,7 @@ def set_predictions(session, submission_id, path_predictions):
                            .options(defer("full_train_y_pred"),
                                     defer("test_y_pred"))
                            .all())
+    all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
     for fold_id, cv_fold in enumerate(all_cv_folds):
         path_results = os.path.join(path_predictions,
                                     'fold_{}'.format(fold_id))
@@ -664,6 +669,7 @@ def set_time(session, submission_id, path_predictions):
                            .options(defer("full_train_y_pred"),
                                     defer("test_y_pred"))
                            .all())
+    all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
     for fold_id, cv_fold in enumerate(all_cv_folds):
         path_results = os.path.join(path_predictions,
                                     'fold_{}'.format(fold_id))
@@ -694,6 +700,7 @@ def set_scores(session, submission_id, path_predictions):
                            .options(defer("full_train_y_pred"),
                                     defer("test_y_pred"))
                            .all())
+    all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
     for fold_id, cv_fold in enumerate(all_cv_folds):
         path_results = os.path.join(path_predictions,
                                     'fold_{}'.format(fold_id))
@@ -806,6 +813,7 @@ def score_submission(session, submission_id):
                            .options(defer("full_train_y_pred"),
                                     defer("test_y_pred"))
                            .all())
+    all_cv_folds = sorted(all_cv_folds, key=lambda x: x.id)
     for submission_on_cv_fold in all_cv_folds:
         submission_on_cv_fold.session = session
         submission_on_cv_fold.compute_train_scores()


### PR DESCRIPTION
closes #292 

The queries on cv folds do not ensure to get always the fold in the exact same order. Therefore, we always sort the fold based on their creation ID.