### PR TITLE
[MRG] Frontend remove button from index

### DIFF
--- a/ramp-frontend/ramp_frontend/templates/index.html
+++ b/ramp-frontend/ramp_frontend/templates/index.html
@@ -168,9 +168,7 @@
                     <br>
                     <span class="text-center"><a class="btn btn-hist font-smaller" href="/description#history" role="button"> Project history » </a></span>
                     <br>
-                    <span class="text-center"><a class="btn btn-hist font-smaller" href="/description#methodology" role="button"> Methodology » </a></span>
-                    <br>
-                    <span class="text-center"><a class="btn btn-hist font-smaller" href="mailto:admin@ramp.studio" role="button"> Contact us » </a></span>
+                    <span class="text-center"><a class="btn btn-hist-pad font-smaller" href="mailto:admin@ramp.studio" role="button"> Contact us » </a></span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
With the update to the description/history page and teach/your challenges page we can get rid of the methodology button (the 'your challenges' button at the top links to the same info)

New button appearance:
![image](https://user-images.githubusercontent.com/23182829/72090659-c7087380-330e-11ea-989d-8a7e8e7ec3a6.png)
