### PR TITLE
BUG disable event name update

### DIFF
--- a/ramp-frontend/ramp_frontend/templates/update_event.html
+++ b/ramp-frontend/ramp_frontend/templates/update_event.html
@@ -38,25 +38,22 @@
          <div class="card-body">
            <form class="ui form" method="post" action="" name="update_event">
                {{ form.hidden_tag() }}
-                   {% if suffix_correct %}
-                        Event name will be {{ event.problem.name }} if you leave suffix empty, or {{ event.problem.name }}_&lt;suffix&gt;. The length should be less than 20 characters, only ascii, no space. It will be used to identify the event, primarily in the url. If you open several events for the same class or hackaton, please use the same suffix consistently.
-                        <div class="form-group">
-                            <label>event suffix</label>
-                            {{ form.suffix(placeholder="event_suffix") }}
-                            {% for error in form.suffix.errors %}
-                                <span style="color: red;">[{{ error }}]</span>
-                            {% endfor %}
-                    {% else %}
+                   {% if not suffix_correct %}
                         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                        Event name does not correspond to the RAMP standards. It should be preceeded by '{{ event.problem.name }}_'. For example '{{ event.problem.name }}_{{ event.name }}'. Please change the name of the event. The length should be less than 20 characters, only ascii, no space. It will be used to identify the event, primarily in the url. If you open several events for the same class or hackaton, please use the same suffix consistently.
-                        <div class="form-group">
-                            <label>event name</label>
-                            {{ form.suffix(placeholder="event_name") }}
+                        Event name does not correspond to the RAMP standards. In the future, please make sure that it is preceeded by the 'problem_name_', eg {form.event.problem_name}_{form.event.name} 
+                    {% endif %}
+                    <!-- in case we want to allow for event_suffix change:
+                    <div class="form-group">
+                        
+                        <label>event suffix</label>
+                            {{ form.suffix(placeholder="event_suffix") }}
+                            
                             {% for error in form.suffix.errors %}
                                 <span style="color: red;">[{{ error }}]</span>
-                            {% endfor %}
-                    {% endif %}
+                            {% endfor %}             
                    </div>
+                   -->   
+                   
                    The title will be used on web pages to name the event. The length should be less than 80 characters. If you open several events for the same class or hackaton, please use the same title consistently.
                    <div class="form-group">
                        <label>event title</label>

--- a/ramp-frontend/ramp_frontend/templates/update_event.html
+++ b/ramp-frontend/ramp_frontend/templates/update_event.html
@@ -37,12 +37,6 @@
         </div>                   
          <div class="card-body">
            <form class="ui form" method="post" action="" name="update_event">
-                {% if not suffix_correct %}
-                    <div class="form-group"></div>
-                        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                        Event name does not correspond to the RAMP standards. In the future, please make sure that it is preceeded by the 'problem_name_', eg: '{{ event.problem.name }}_{{ event.name }}'
-                    </div>
-                {% endif %}
                     <!-- in case we want to allow for event_suffix change:
                     <div class="form-group">
                         

--- a/ramp-frontend/ramp_frontend/templates/update_event.html
+++ b/ramp-frontend/ramp_frontend/templates/update_event.html
@@ -37,10 +37,10 @@
         </div>                   
          <div class="card-body">
            <form class="ui form" method="post" action="" name="update_event">
-               {{ form.hidden_tag() }}
+                <div class="form-group"></div>
                    {% if not suffix_correct %}
                         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                        Event name does not correspond to the RAMP standards. In the future, please make sure that it is preceeded by the 'problem_name_', eg {form.event.problem_name}_{form.event.name} 
+                        Event name does not correspond to the RAMP standards. In the future, please make sure that it is preceeded by the 'problem_name_', eg: '{{ event.problem.name }}_{{ event.name }}'
                     {% endif %}
                     <!-- in case we want to allow for event_suffix change:
                     <div class="form-group">
@@ -53,7 +53,7 @@
                             {% endfor %}             
                    </div>
                    -->   
-                   
+                </div>
                    The title will be used on web pages to name the event. The length should be less than 80 characters. If you open several events for the same class or hackaton, please use the same title consistently.
                    <div class="form-group">
                        <label>event title</label>

--- a/ramp-frontend/ramp_frontend/templates/update_event.html
+++ b/ramp-frontend/ramp_frontend/templates/update_event.html
@@ -37,11 +37,12 @@
         </div>                   
          <div class="card-body">
            <form class="ui form" method="post" action="" name="update_event">
-                <div class="form-group"></div>
-                   {% if not suffix_correct %}
+                {% if not suffix_correct %}
+                    <div class="form-group"></div>
                         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                         Event name does not correspond to the RAMP standards. In the future, please make sure that it is preceeded by the 'problem_name_', eg: '{{ event.problem.name }}_{{ event.name }}'
-                    {% endif %}
+                    </div>
+                {% endif %}
                     <!-- in case we want to allow for event_suffix change:
                     <div class="form-group">
                         
@@ -53,7 +54,6 @@
                             {% endfor %}             
                    </div>
                    -->   
-                </div>
                    The title will be used on web pages to name the event. The length should be less than 80 characters. If you open several events for the same class or hackaton, please use the same title consistently.
                    <div class="form-group">
                        <label>event title</label>

--- a/ramp-frontend/ramp_frontend/templates/update_event.html
+++ b/ramp-frontend/ramp_frontend/templates/update_event.html
@@ -38,13 +38,24 @@
          <div class="card-body">
            <form class="ui form" method="post" action="" name="update_event">
                {{ form.hidden_tag() }}
-                   Event name will be {{ event.problem.name }} if you leave suffix empty, or {{ event.problem.name }}_&lt;suffix&gt;. The length should be less than 20 characters, only ascii, no space. It will be used to identify the event, primarily in the url. If you open several events for the same class or hackaton, please use the same suffix consistently.
-                   <div class="form-group">
-                       <label>event suffix</label>
-                       {{ form.suffix(placeholder="event_suffix") }}
-                       {% for error in form.suffix.errors %}
-                           <span style="color: red;">[{{ error }}]</span>
-                       {% endfor %}
+                   {% if suffix_correct %}
+                        Event name will be {{ event.problem.name }} if you leave suffix empty, or {{ event.problem.name }}_&lt;suffix&gt;. The length should be less than 20 characters, only ascii, no space. It will be used to identify the event, primarily in the url. If you open several events for the same class or hackaton, please use the same suffix consistently.
+                        <div class="form-group">
+                            <label>event suffix</label>
+                            {{ form.suffix(placeholder="event_suffix") }}
+                            {% for error in form.suffix.errors %}
+                                <span style="color: red;">[{{ error }}]</span>
+                            {% endfor %}
+                    {% else %}
+                        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                        Event name does not correspond to the RAMP standards. It should be preceeded by '{{ event.problem.name }}_'. For example '{{ event.problem.name }}_{{ event.name }}'. Please change the name of the event. The length should be less than 20 characters, only ascii, no space. It will be used to identify the event, primarily in the url. If you open several events for the same class or hackaton, please use the same suffix consistently.
+                        <div class="form-group">
+                            <label>event name</label>
+                            {{ form.suffix(placeholder="event_name") }}
+                            {% for error in form.suffix.errors %}
+                                <span style="color: red;">[{{ error }}]</span>
+                            {% endfor %}
+                    {% endif %}
                    </div>
                    The title will be used on web pages to name the event. The length should be less than 80 characters. If you open several events for the same class or hackaton, please use the same title consistently.
                    <div class="form-group">

--- a/ramp-frontend/ramp_frontend/views/admin.py
+++ b/ramp-frontend/ramp_frontend/views/admin.py
@@ -201,13 +201,6 @@ def update_event(event_name):
                 .format(flask_login.current_user.name, event.name))
     admin = is_admin(db.session, event_name, flask_login.current_user.name)
     # We assume here that event name has the syntax <problem_name>_<suffix>
-    # make sure that the event has the syntax <problem_name>_<suffix>
-    is_suffix_correct = event.name.startswith(event.problem + '_'):
-        # suffix correct
-        suffix_correct = True
-    else:
-        # suffix is not correct. keep the full name
-        suffix_correct = False
 
     h = event.min_duration_between_submissions // 3600
     m = event.min_duration_between_submissions // 60 % 60
@@ -272,7 +265,6 @@ def update_event(event_name):
     return render_template(
         'update_event.html',
         form=form,
-        suffix_correct=suffix_correct,
         event=event,
         admin=admin,
         asked=asked,

--- a/ramp-frontend/ramp_frontend/views/admin.py
+++ b/ramp-frontend/ramp_frontend/views/admin.py
@@ -202,21 +202,19 @@ def update_event(event_name):
     admin = is_admin(db.session, event_name, flask_login.current_user.name)
     # We assume here that event name has the syntax <problem_name>_<suffix>
     # make sure that the event has the syntax <problem_name>_<suffix>
-    #import pdb; pdb.set_trace()
     if event.name[:len(event.problem.name) + 1] == event.problem.name + '_':
         # suffix correct
-        suffix = event.name[len(event.problem.name) + 1:]
+        #suffix = event.name[len(event.problem.name) + 1:]
         suffix_correct = True
     else:
         # suffix is not correct. keep the full name
-        suffix = event.name
+        #suffix = event.name
         suffix_correct = False
 
     h = event.min_duration_between_submissions // 3600
     m = event.min_duration_between_submissions // 60 % 60
     s = event.min_duration_between_submissions % 60
     form = EventUpdateProfileForm(
-        suffix=suffix,
         title=event.title,
         is_send_trained_mails=event.is_send_trained_mails,
         is_send_submitted_mails=event.is_send_submitted_mails,
@@ -232,12 +230,6 @@ def update_event(event_name):
     )
     if form.validate_on_submit():
         try:
-            if form.suffix.data == '':
-                event.name = event.problem.name
-            elif suffix_correct:
-                event.name = event.problem.name + '_' + form.suffix.data
-            else:
-                event.name = form.suffix.data
             event.title = form.title.data
             event.is_send_trained_mails = form.is_send_trained_mails.data
             event.is_send_submitted_mails = form.is_send_submitted_mails.data

--- a/ramp-frontend/ramp_frontend/views/admin.py
+++ b/ramp-frontend/ramp_frontend/views/admin.py
@@ -204,11 +204,9 @@ def update_event(event_name):
     # make sure that the event has the syntax <problem_name>_<suffix>
     if event.name[:len(event.problem.name) + 1] == event.problem.name + '_':
         # suffix correct
-        #suffix = event.name[len(event.problem.name) + 1:]
         suffix_correct = True
     else:
         # suffix is not correct. keep the full name
-        #suffix = event.name
         suffix_correct = False
 
     h = event.min_duration_between_submissions // 3600

--- a/ramp-frontend/ramp_frontend/views/admin.py
+++ b/ramp-frontend/ramp_frontend/views/admin.py
@@ -202,7 +202,7 @@ def update_event(event_name):
     admin = is_admin(db.session, event_name, flask_login.current_user.name)
     # We assume here that event name has the syntax <problem_name>_<suffix>
     # make sure that the event has the syntax <problem_name>_<suffix>
-    
+    #import pdb; pdb.set_trace()
     if event.name[:len(event.problem.name) + 1] == event.problem.name + '_':
         # suffix correct
         suffix = event.name[len(event.problem.name) + 1:]
@@ -216,7 +216,7 @@ def update_event(event_name):
     m = event.min_duration_between_submissions // 60 % 60
     s = event.min_duration_between_submissions % 60
     form = EventUpdateProfileForm(
-        suffix=suffix, suffix_correct=suffix_correct,
+        suffix=suffix,
         title=event.title,
         is_send_trained_mails=event.is_send_trained_mails,
         is_send_submitted_mails=event.is_send_submitted_mails,
@@ -282,6 +282,7 @@ def update_event(event_name):
     return render_template(
         'update_event.html',
         form=form,
+        suffix_correct=suffix_correct,
         event=event,
         admin=admin,
         asked=asked,

--- a/ramp-frontend/ramp_frontend/views/admin.py
+++ b/ramp-frontend/ramp_frontend/views/admin.py
@@ -202,7 +202,7 @@ def update_event(event_name):
     admin = is_admin(db.session, event_name, flask_login.current_user.name)
     # We assume here that event name has the syntax <problem_name>_<suffix>
     # make sure that the event has the syntax <problem_name>_<suffix>
-    if event.name[:len(event.problem.name) + 1] == event.problem.name + '_':
+    is_suffix_correct = event.name.startswith(event.problem + '_'):
         # suffix correct
         suffix_correct = True
     else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->

#### What does this implement/fix? Explain your changes.
- It disables the option to change the event_name from the fronted
- if the event_name is already set wrong it displays the message to keep with the RAMP standards in the future.

1. **Before, if the event was wrongly named:** 
![before_wrong](https://user-images.githubusercontent.com/2219642/72424626-926d3f80-3786-11ea-9b1d-45fc55a3a5fa.png)

2. **Before, if the event was correctly named:**
![before_correct](https://user-images.githubusercontent.com/2219642/72424654-a0bb5b80-3786-11ea-89f3-bc7ecb9a5bb5.png)

3. **After, if the event was wrongly named:**
![after_wrong](https://user-images.githubusercontent.com/2219642/72424689-add84a80-3786-11ea-9a2a-24009bd9b59e.png)

4. **After, if the event was correctly named:**
![after_correct](https://user-images.githubusercontent.com/2219642/72424724-b92b7600-3786-11ea-9d5f-c24e404f6d44.png)






#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
