### PR TITLE
BUG correct time showed in leaderboard

### DIFF
--- a/ramp-database/ramp_database/tools/leaderboard.py
+++ b/ramp-database/ramp_database/tools/leaderboard.py
@@ -122,8 +122,6 @@ def _compute_leaderboard(session, submissions, leaderboard_type, event_name,
                                             score_order,
                                             stats_order)
     ]
-    for x in score_list:
-        print("<th>{}</th>".format(x))
     # Only display train and validation time for the public leaderboard
     time_list = (['train time [s]', 'validation time [s]', 'test time [s]']
                  if leaderboard_type == 'private'

--- a/ramp-database/ramp_database/tools/leaderboard.py
+++ b/ramp-database/ramp_database/tools/leaderboard.py
@@ -61,24 +61,22 @@ def _compute_leaderboard(session, submissions, leaderboard_type, event_name,
         df_time = df_time.rename(columns={0: 'time'})
         df_time = df_time.sum(axis=0, level="step").T
 
-        # df = pd.concat([df_scores], axis=1)
-        df = df_scores
-        df_mean = df.groupby('step').mean()
-        df_std = df.groupby('step').std()
+        df_scores_mean = df_scores.groupby('step').mean()
+        df_scores_std = df_scores.groupby('step').std()
 
         # select only the validation and testing steps and rename them to
         # public and private
         map_renaming = {'valid': 'public', 'test': 'private'}
-        df_mean = (df_mean.loc[list(map_renaming.keys())]
-                          .rename(index=map_renaming)
-                          .stack().to_frame().T)
-        df_std = (df_std.loc[list(map_renaming.keys())]
-                        .rename(index=map_renaming)
-                        .stack().to_frame().T)
+        df_scores_mean = (df_scores_mean.loc[list(map_renaming.keys())]
+                                        .rename(index=map_renaming)
+                                        .stack().to_frame().T)
+        df_scores_std = (df_scores_std.loc[list(map_renaming.keys())]
+                                      .rename(index=map_renaming)
+                                      .stack().to_frame().T)
         df_scores_bag = (df_scores_bag.rename(index=map_renaming)
                                       .stack().to_frame().T)
 
-        df = pd.concat([df_scores_bag, df_mean, df_std], axis=1,
+        df = pd.concat([df_scores_bag, df_scores_mean, df_scores_std], axis=1,
                        keys=['bag', 'mean', 'std'])
 
         df.columns = df.columns.set_names(['stat', 'set', 'score'])
@@ -94,7 +92,6 @@ def _compute_leaderboard(session, submissions, leaderboard_type, event_name,
                      'test': 'test time [s]'}
         )
         df = pd.concat([df, df_time], axis=1)
-        # TODO: only show valid in public and test on private
 
         df['team'] = sub.team.name
         df['submission'] = sub.name_with_link if with_links else sub.name

--- a/ramp-database/ramp_database/tools/leaderboard.py
+++ b/ramp-database/ramp_database/tools/leaderboard.py
@@ -118,9 +118,12 @@ def _compute_leaderboard(session, submissions, leaderboard_type, event_name,
                     if score_type.name != event.official_score_name])
     score_list = [
         '{} {} {}'.format(stat, dataset, score)
-        for stat, dataset, score in product(stats_order, dataset_order,
-                                            score_order)
+        for dataset, score, stat in product(dataset_order,
+                                            score_order,
+                                            stats_order)
     ]
+    for x in score_list:
+        print("<th>{}</th>".format(x))
     # Only display train and validation time for the public leaderboard
     time_list = (['train time [s]', 'validation time [s]', 'test time [s]']
                  if leaderboard_type == 'private'

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -199,28 +199,28 @@ def test_get_leaderboard(session_toy_db):
     assert """<th>team</th>
       <th>submission</th>
       <th>bag public acc</th>
-      <th>bag public error</th>
-      <th>bag public nll</th>
-      <th>bag public f1_70</th>
-      <th>bag private acc</th>
-      <th>bag private error</th>
-      <th>bag private nll</th>
-      <th>bag private f1_70</th>
       <th>mean public acc</th>
-      <th>mean public error</th>
-      <th>mean public nll</th>
-      <th>mean public f1_70</th>
-      <th>mean private acc</th>
-      <th>mean private error</th>
-      <th>mean private nll</th>
-      <th>mean private f1_70</th>
       <th>std public acc</th>
+      <th>bag public error</th>
+      <th>mean public error</th>
       <th>std public error</th>
+      <th>bag public nll</th>
+      <th>mean public nll</th>
       <th>std public nll</th>
+      <th>bag public f1_70</th>
+      <th>mean public f1_70</th>
       <th>std public f1_70</th>
+      <th>bag private acc</th>
+      <th>mean private acc</th>
       <th>std private acc</th>
+      <th>bag private error</th>
+      <th>mean private error</th>
       <th>std private error</th>
+      <th>bag private nll</th>
+      <th>mean private nll</th>
       <th>std private nll</th>
+      <th>bag private f1_70</th>
+      <th>mean private f1_70</th>
       <th>std private f1_70</th>
       <th>contributivity</th>
       <th>historical contributivity</th>

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -40,7 +40,7 @@ def session_toy_db(database_connection):
 
 
 @pytest.fixture
-def session_toy_function():
+def session_toy_function(database_connection):
     database_config = read_config(database_config_template())
     ramp_config = ramp_config_template()
     try:
@@ -225,6 +225,7 @@ def test_get_leaderboard(session_toy_db):
       <th>contributivity</th>
       <th>historical contributivity</th>
       <th>train time [s]</th>
+      <th>validation time [s]</th>
       <th>test time [s]</th>
       <th>max RAM [MB]</th>
       <th>submitted at (UTC)</th>""" in leaderboard_private
@@ -237,7 +238,7 @@ def test_get_leaderboard(session_toy_db):
       <th>contributivity</th>
       <th>historical contributivity</th>
       <th>train time [s]</th>
-      <th>test time [s]</th>
+      <th>validation time [s]</th>
       <th>max RAM [MB]</th>
       <th>submitted at (UTC)</th>""" in leaderboard_public
     assert """<th>team</th>
@@ -251,7 +252,7 @@ def test_get_leaderboard(session_toy_db):
       <th>submission</th>
       <th>acc</th>
       <th>train time [s]</th>
-      <th>test time [s]</th>
+      <th>validation time [s]</th>
       <th>submitted at (UTC)</th>""" in competition_public
     assert """<th>rank</th>
       <th>move</th>
@@ -259,5 +260,6 @@ def test_get_leaderboard(session_toy_db):
       <th>submission</th>
       <th>acc</th>
       <th>train time [s]</th>
+      <th>validation time [s]</th>
       <th>test time [s]</th>
       <th>submitted at (UTC)</th>""" in competition_private


### PR DESCRIPTION
closes #285

This PR proposes to:

1. give the total score over the fold and not the mean time
2. correct the training time

TODO:

- [x] Reorder the score in the private leaderboard

I don't want to:

1. fix the rounding. I think this is YAGNI, forcing to use a verbose code instead of `df.round`
2. change public -> valid and private -> test
