### PR TITLE
ENH add numerical ID in private leaderboard

### DIFF
--- a/ramp-database/ramp_database/tools/leaderboard.py
+++ b/ramp-database/ramp_database/tools/leaderboard.py
@@ -93,6 +93,8 @@ def _compute_leaderboard(session, submissions, leaderboard_type, event_name,
         )
         df = pd.concat([df, df_time], axis=1)
 
+        if leaderboard_type == 'private':
+            df['submission ID'] = sub.basename.replace('submission_', '')
         df['team'] = sub.team.name
         df['submission'] = sub.name_with_link if with_links else sub.name
         df['contributivity'] = int(round(100 * sub.contributivity))
@@ -133,6 +135,8 @@ def _compute_leaderboard(session, submissions, leaderboard_type, event_name,
         time_list +
         ['max RAM [MB]', 'submitted at (UTC)']
     )
+    if leaderboard_type == "private":
+        col_ordered = ["submission ID"] + col_ordered
     df = df[col_ordered]
 
     df = df.sort_values(

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -196,7 +196,8 @@ def test_get_leaderboard(session_toy_db):
         assert private_term in leaderboard_private
 
     # check the column name in each leaderboard
-    assert """<th>team</th>
+    assert """<th>submission ID</th>
+      <th>team</th>
       <th>submission</th>
       <th>bag public acc</th>
       <th>mean public acc</th>


### PR DESCRIPTION
closes #294 

@rth is it what you wanted as a feature. Add the ID in the private leaderboard?