### PR TITLE
ENH add submission state in my_submission frontend page

### DIFF
--- a/ramp-database/ramp_database/tools/leaderboard.py
+++ b/ramp-database/ramp_database/tools/leaderboard.py
@@ -307,24 +307,22 @@ def get_leaderboard(session, leaderboard_type, event_name, user_name=None,
             with_links=with_links
         )
     elif leaderboard_type in ['new', 'failed']:
-        columns = ['team',
-                   'submission',
-                   'submitted at (UTC)']
-
-        if leaderboard_type == 'failed':
-            columns.append('error')
+        if leaderboard_type == 'new':
+            columns = ['team', 'submission', 'submitted at (UTC)', 'state']
+        else:
+            columns = ['team', 'submission', 'submitted at (UTC)', 'error']
 
         # we rely on the zip function ignore the submission state if the error
         # column was not appended
-        data = [
-            {column: value
-             for column, value in zip(columns,
-                                      [sub.event_team.team.name,
-                                       sub.name_with_link,
-                                       pd.Timestamp(sub.submission_timestamp),
-                                       sub.state_with_link])}
-            for sub in submissions
-        ]
+        data = [{
+            column: value for column, value in zip(
+                columns,
+                [sub.event_team.team.name,
+                 sub.name_with_link,
+                 pd.Timestamp(sub.submission_timestamp),
+                 (sub.state_with_link if leaderboard_type == 'error'
+                  else sub.state)])
+            } for sub in submissions]
         df = pd.DataFrame(data, columns=columns)
     else:
         # make some extra filtering

--- a/ramp-engine/ramp_engine/dispatcher.py
+++ b/ramp-engine/ramp_engine/dispatcher.py
@@ -20,6 +20,7 @@ from ramp_database.tools.submission import set_submission_state
 
 from ramp_database.tools.leaderboard import update_all_user_leaderboards
 from ramp_database.tools.leaderboard import update_leaderboards
+from ramp_database.tools.leaderboard import update_user_leaderboards
 
 from ramp_database.utils import session_scope
 
@@ -114,6 +115,10 @@ class Dispatcher:
             # create the worker
             worker = self.worker(self._worker_config, submission_name)
             set_submission_state(session, submission_id, 'sent_to_training')
+            update_user_leaderboards(
+                session, self._ramp_config['event_name'],
+                submission .team.name, new_only=True,
+            )
             self._awaiting_worker_queue.put_nowait((worker, (submission_id,
                                                              submission_name)))
             logger.info('Submission {} added to the queue of submission to be '
@@ -129,6 +134,11 @@ class Dispatcher:
             worker.setup()
             worker.launch_submission()
             set_submission_state(session, submission_id, 'training')
+            submission = get_submission_by_id(session, submission_id)
+            update_user_leaderboards(
+                session, self._ramp_config['event_name'],
+                submission.team.name, new_only=True,
+            )
             self._processing_worker_queue.put_nowait(
                 (worker, (submission_id, submission_name)))
             logger.info('Store the worker {} into the processing queue'


### PR DESCRIPTION
closes #277

Add the state of the submission to know if it is training or only send_to_training.
We need to add a column in the DB and update the position in the queue if we want to add this information. I will let it for another PR.