### PR TITLE
Sandbox: Submit button popup

### DIFF
--- a/ramp-frontend/ramp_frontend/templates/sandbox.html
+++ b/ramp-frontend/ramp_frontend/templates/sandbox.html
@@ -132,9 +132,9 @@
                     <div class="modal fade" id="submit_Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
                       <div class="modal-dialog" role="document">
                       <div class="modal-content">
-                          <div class="modal-header" STYLE="background-color: #ee8c7a">
+                          <div class="modal-header">
                           <h3 class="modal-title" id="exampleModalLabel"></i>
-                              Submit code for {{ event.name }}</h3>
+                              Submit code</h3>
                           </div>
                           <div class="required field">
                             <label>Submission name (between 4 and 20 characters)</label>

--- a/ramp-frontend/ramp_frontend/templates/sandbox.html
+++ b/ramp-frontend/ramp_frontend/templates/sandbox.html
@@ -106,6 +106,7 @@
           <br />
           <br />
           <div class="container">
+            <!--
             <div class="row">
               <center>
                 <div class="required field">
@@ -115,12 +116,42 @@
               </center>
             </div>
             <br />
+          -->
             <div class="row">
               <div class="col-xs-6">
                 <center>
                   <input type="submit" value="Save for later" class="ui submit button", name="saving">
+                  {% if event_status["state"] == 'close' %}
+                      <input button type="button" value="Submit now" class="btn btn-secondary disabled" >
+                  {% else %}
+                      <button type="button" class="ui submit button" data-toggle="modal" data-target="#submit_Modal">
+                        Submit now
+                      </button>
+                  
+                    <!-- Modal -->
+                    <div class="modal fade" id="submit_Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                      <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                          <div class="modal-header" STYLE="background-color: #ee8c7a">
+                          <h3 class="modal-title" id="exampleModalLabel"></i>
+                              Submit code for {{ event.name }}</h3>
+                          </div>
+                          <div class="required field">
+                            <label>Submission name (between 4 and 20 characters)</label>
+                              {{ submit_form.submission_name }}
+                          </div>
+                          <div class="modal-footer">
+                          <button type="submit" class="btn btn-primary" data-dismiss="modal" id="entered">Cancel</button>
+                          <input type="submit" value="Submit now" class="ui submit button" name="submission">
+                          <!--<button type="submit" name="submit_button" class="ui submit button" value='Submit now'>Submit</button>-->
+                          </div>
+                      </div>
+                      </div>
+                  </div>
+                {% endif %}
                 </center>
               </div>
+              <!--
               <div class="col-xs-6">
                 <center>
                   {% if event_status["state"] == 'close' %}
@@ -130,6 +161,7 @@
                   {% endif %}
                 </center>
               </div>
+            -->
             </div>
           </div>
         </form>

--- a/ramp-frontend/ramp_frontend/templates/sandbox.html
+++ b/ramp-frontend/ramp_frontend/templates/sandbox.html
@@ -94,7 +94,7 @@
               </div>
             {% endfor %}
            <br />
-           <br />
+           <center>
            <div class="card-header">
             <div class="card-title">
               <div class="title">
@@ -102,21 +102,11 @@
               </div>
             </div>
           </div>
+        </center>
           </div>
           <br />
-          <br />
+ 
           <div class="container">
-            <!--
-            <div class="row">
-              <center>
-                <div class="required field">
-                  <label>Submission name (between 4 and 20 characters)</label>
-                    {{ submit_form.submission_name }}
-                </div>
-              </center>
-            </div>
-            <br />
-          -->
             <div class="row">
               <div class="col-xs-6">
                 <center>

--- a/ramp-frontend/ramp_frontend/views/ramp.py
+++ b/ramp-frontend/ramp_frontend/views/ramp.py
@@ -489,12 +489,19 @@ def sandbox(event_name):
                     'Submission {} already exists. Please change the name.'
                     .format(new_submission_name)
                 )
+                
             except MissingExtensionError:
                 return redirect_to_sandbox(
                     event, 'Missing extension'
                 )
             except TooEarlySubmissionError as e:
                 return redirect_to_sandbox(event, str(e))
+
+            except:
+                return redirect_to_sandbox(
+                    event,
+                    'error'
+                )
 
             logger.info('{} submitted {} for {}.'
                         .format(flask_login.current_user.name,

--- a/ramp-frontend/ramp_frontend/views/ramp.py
+++ b/ramp-frontend/ramp_frontend/views/ramp.py
@@ -489,19 +489,13 @@ def sandbox(event_name):
                     'Submission {} already exists. Please change the name.'
                     .format(new_submission_name)
                 )
-                
+
             except MissingExtensionError:
                 return redirect_to_sandbox(
                     event, 'Missing extension'
                 )
             except TooEarlySubmissionError as e:
                 return redirect_to_sandbox(event, str(e))
-
-            except:
-                return redirect_to_sandbox(
-                    event,
-                    'error'
-                )
 
             logger.info('{} submitted {} for {}.'
                         .format(flask_login.current_user.name,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Changes done to the layout of sandbox. Now the name of the submission is only given after submit button is pushed

- this is how it was before:
![before](https://user-images.githubusercontent.com/2219642/72911920-2b79f880-3d3b-11ea-99c3-63381e43734d.png)

- now it looks like:
![after](https://user-images.githubusercontent.com/2219642/72911947-36348d80-3d3b-11ea-9cee-dc06e732fb7b.png)

- pop up message:
![after_popup](https://user-images.githubusercontent.com/2219642/72911969-3c2a6e80-3d3b-11ea-8213-9709743f404f.png)




#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
