### PR TITLE
BUG/DOC fix standalone worker

### DIFF
--- a/doc/running_challenge.rst
+++ b/doc/running_challenge.rst
@@ -1,8 +1,6 @@
-###############################
-Useful tips when running a RAMP
-###############################
-
-When running a RAMP challenge, you might need one of the following tips.
+######################
+Useful tips using RAMP
+######################
 
 How to restart a failed submission manually
 -------------------------------------------
@@ -15,3 +13,42 @@ You can use the following command to change the status of a submission::
 
 Since the submission was set to ``new``, the RAMP dispatcher will automatically
 pick up this submission to train it again.
+
+Running a standalone worker without connection to database
+----------------------------------------------------------
+
+It can happen that you want to use a worker to run a submission locally to
+reproduce what the dispatcher is doing or just train a local submission.
+You can use the command `ramp launch worker` to this regard. What you need
+is to provide a configuration file with the information regarding the
+submission and the worker. For instance, let's imagine that you cloned the
+iris kit in locally and that you want to run one of the submission.
+
+We cloned the iris repository in::
+
+    /home/user/Documents/ramp/iris
+
+Now, we need to provide a configuration file containing the information used
+by the worker. For instance, for a conda worker, we will provide the following
+`config.yml`::
+
+    ramp:
+        problem_name: iris
+        event_name: iris_test
+        event_title: "Human readable event name to display on website"
+        event_is_public: true
+        data_dir: /home/user/Documents/ramp/iris
+        kit_dir: /home/user/Documents/ramp/iris
+        submissions_dir: /home/user/Documents/ramp/iris/submissions
+        predictions_dir: /home/user/Documents/ramp/iris/predictions
+        logs_dir: /home/user/Documents/ramp/iris/logs
+        sandbox_dir: starting_kit
+    worker:
+        worker_type: conda
+        conda_env: ramp-iris
+
+Then, you can launch the worker for the submission `random_forest_10_10` as::
+
+    ~/Documents/ramp/iris $ ramp launch worker --submission random_forest_10_10
+
+And you can check the results in the `logs` folder.

--- a/ramp-engine/ramp_engine/cli.py
+++ b/ramp-engine/ramp_engine/cli.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import click
 

--- a/ramp-engine/ramp_engine/cli.py
+++ b/ramp-engine/ramp_engine/cli.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import click
 
@@ -61,14 +62,12 @@ def dispatcher(config, event_config, n_workers, n_threads, hunger_policy,
 
 
 @main.command()
-@click.option("--config", default='config.yml', show_default=True,
-              help='Configuration file in YAML format')
-@click.option("--event-config", show_default=True,
+@click.option("--event-config", default='config.yml', show_default=True,
               help='Configuration file in YAML format containing the RAMP '
               'event information.')
 @click.option('--submission', help='The submission name')
 @click.option('-v', '--verbose', is_flag=True)
-def worker(config, event_config, submission, verbose):
+def worker(event_config, submission, verbose):
     """Launch a standalone RAMP worker.
 
     The RAMP worker is in charger of processing a single submission by
@@ -83,7 +82,8 @@ def worker(config, event_config, submission, verbose):
             format='%(asctime)s - %(levelname)s - %(name)s - %(message)s',
             level=level, datefmt='%Y:%m:%d %H:%M:%S'
         )
-    worker_params = generate_worker_config(event_config, config)
+    config = read_config(event_config)
+    worker_params = generate_worker_config(config)
     worker_type = available_workers[worker_params['worker_type']]
     worker = worker_type(worker_params, submission)
     worker.launch()

--- a/ramp-engine/ramp_engine/tests/test_cli.py
+++ b/ramp-engine/ramp_engine/tests/test_cli.py
@@ -48,7 +48,6 @@ def test_dispatcher(verbose_params, make_toy_db):
 def test_worker(verbose_params, make_toy_db):
     runner = CliRunner()
     cmd = ["worker",
-           "--config", ramp_config_template(),
            "--event-config", ramp_config_template(),
            "--submission", "starting_kit"]
     if verbose_params is not None:


### PR DESCRIPTION
closes #201 

Make sure we only need a config file for the worker with the specific path.
I also added a part in the documentation to replicate how to train locally using a worker.