### PR TITLE
MNT add dispatcher parameters inside the config file

### DIFF
--- a/doc/create_ramp_event.rst
+++ b/doc/create_ramp_event.rst
@@ -40,6 +40,10 @@ This config file should look like::
     worker:
         worker_type: conda
         conda_env: ramp-iris
+    dispatcher:
+        hunger_policy: sleep
+        n_workers: 2
+        n_threads: 2
 
 .. note::
     - <event_name> must always be preceeded with the '<problem_name>_' as in

--- a/ramp-engine/ramp_engine/cli.py
+++ b/ramp-engine/ramp_engine/cli.py
@@ -25,16 +25,8 @@ def main():
 @click.option("--event-config", show_default=True,
               help='Configuration file in YAML format containing the RAMP '
               'event information.')
-@click.option('--n-workers', default=-1, show_default=True,
-              help='Number of worker to start in parallel.')
-@click.option('--n-threads', default=None, show_default=None, type=int,
-              help='Number of threads used by each worker.')
-@click.option('--hunger-policy', default='exit', show_default=True,
-              help='Policy to apply in case that there is no anymore workers'
-              'to be processed.')
 @click.option('-v', '--verbose', count=True)
-def dispatcher(config, event_config, n_workers, n_threads, hunger_policy,
-               verbose):
+def dispatcher(config, event_config, verbose):
     """Launch the RAMP dispatcher.
 
     The RAMP dispatcher is in charge of starting RAMP workers, collecting
@@ -53,6 +45,13 @@ def dispatcher(config, event_config, n_workers, n_threads, hunger_policy,
     worker_type = available_workers[
         internal_event_config['worker']['worker_type']
     ]
+
+    dispatcher_config = (internal_event_config['dispatcher']
+                         if 'dispatcher' in internal_event_config else {})
+    n_workers = dispatcher_config.get('n_workers', -1)
+    n_threads = dispatcher_config.get('n_threads', None)
+    hunger_policy = dispatcher_config.get('hunger_policy', 'exit')
+
     disp = Dispatcher(
         config=config, event_config=event_config, worker=worker_type,
         n_workers=n_workers, n_threads=n_threads, hunger_policy=hunger_policy

--- a/ramp-utils/ramp_utils/template/ramp_config_template.yml
+++ b/ramp-utils/ramp_utils/template/ramp_config_template.yml
@@ -12,3 +12,7 @@ ramp:
 worker:
     worker_type: <conda or aws>
     ...
+dispatcher:
+    hunger_policy: sleep
+    # n_workers: (number of RAMP workers launched in parallel. Default: # CPUs)
+    # n_threads: (number of threads used by a RAMP worker: Default: # CPUs)


### PR DESCRIPTION
We can move the parameter of the dispatcher inside the event config file since we are triggering a dispatcher by event. It will be much simpler to launch them then.