### PR TITLE
BUG sign up not working correctly

### DIFF
--- a/doc/whats_new/v0.4.rst
+++ b/doc/whats_new/v0.4.rst
@@ -23,5 +23,9 @@ Changelog
   "My submission" menu.
   :pr:`408` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- Bug: fix a bug which was not showing modal box during sign-in due to lack
+  of redirection.
+  :pr:`412` by :user:`Maria Telenczuk <maikia>`.
+
 `ramp-utils`
 ............

--- a/ramp-frontend/ramp_frontend/tests/test_auth.py
+++ b/ramp-frontend/ramp_frontend/tests/test_auth.py
@@ -176,7 +176,7 @@ def test_sign_up(client_session):
     user_profile = {'user_name': 'xx', 'password': 'xx', 'firstname': 'xx',
                     'lastname': 'xx', 'email': 'xx'}
     rv = client.post('/sign_up', data=user_profile)
-    assert rv.status_code == 200
+    assert rv.status_code == 302
     user = get_user_by_name(session, 'xx')
     assert user.name == 'xx'
     user_profile = {'user_name': 'yy', 'password': 'yy', 'firstname': 'yy',
@@ -184,7 +184,7 @@ def test_sign_up(client_session):
     rv = client.post('/sign_up', data=user_profile, follow_redirects=True)
     assert rv.status_code == 200
 
-    def _assert_flash(url, data, status_code=200,
+    def _assert_flash(url, data, status_code=302,
                       message='username is already in use'):
         rv = client.post('/sign_up', data=data)
         with client.session_transaction() as cs:
@@ -240,7 +240,7 @@ def test_sign_up_with_approval(client_session):
                 confirm_email_link.find('/confirm_email'):
             ]
             # check the redirection
-            assert rv.status_code == 200
+            assert rv.status_code == 302
             user = get_user_by_name(session, 'new_user_1')
             assert user is not None
             assert user.access_level == 'not_confirmed'

--- a/ramp-frontend/ramp_frontend/views/auth.py
+++ b/ramp-frontend/ramp_frontend/views/auth.py
@@ -170,7 +170,8 @@ def sign_up():
             "We sent a confirmation email. Go read your email and click on "
             "the confirmation link"
         )
-        return render_template('index.html')
+        #return render_template('index.html')
+        return redirect(url_for('login'))
     return render_template('sign_up.html', form=form)
 
 

--- a/ramp-frontend/ramp_frontend/views/auth.py
+++ b/ramp-frontend/ramp_frontend/views/auth.py
@@ -146,7 +146,7 @@ def sign_up():
                 access_level='not_confirmed'
             )
         except NameClashError as e:
-            flash(str(e), category='Sign-up error')
+            flash(str(e))
             logger.info(str(e))
             return redirect(url_for('auth.sign_up'))
         # send an email to the participant such that he can confirm his email

--- a/ramp-frontend/ramp_frontend/views/auth.py
+++ b/ramp-frontend/ramp_frontend/views/auth.py
@@ -147,6 +147,7 @@ def sign_up():
             )
         except NameClashError as e:
             flash(str(e), category='Sign-up error')
+            logger.info(str(e))
             return redirect(url_for('auth.sign_up'))
         # send an email to the participant such that he can confirm his email
         token = ts.dumps(user.email)

--- a/ramp-frontend/ramp_frontend/views/auth.py
+++ b/ramp-frontend/ramp_frontend/views/auth.py
@@ -146,9 +146,8 @@ def sign_up():
                 access_level='not_confirmed'
             )
         except NameClashError as e:
-            flash(str(e))
-            logger.info(str(e))
-            return render_template('index.html')
+            flash(str(e), category='Sign-up error')
+            return redirect(url_for('auth.sign_up'))
         # send an email to the participant such that he can confirm his email
         token = ts.dumps(user.email)
         recover_url = url_for(
@@ -170,8 +169,7 @@ def sign_up():
             "We sent a confirmation email. Go read your email and click on "
             "the confirmation link"
         )
-        #return render_template('index.html')
-        return redirect(url_for('login'))
+        return redirect(url_for('auth.login'))
     return render_template('sign_up.html', form=form)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #404
Now on the sign up the user is redirected to the index page without any message. The e-mail is send and the message pops up only if the user clicks sign up afterwards

This must be happening righ after the user signs up, before he is redirected (probably loading the page is now too fast and must be slown down as in the previous version)

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
