### PR TITLE
BUG always make copy of external data

### DIFF
--- a/doc/whats_new/v0.4.rst
+++ b/doc/whats_new/v0.4.rst
@@ -9,6 +9,10 @@ Changelog
 `ramp-database`
 ...............
 
+- Bug: fix a bug which was always doing a symlink of the external data.
+Instead, we now always copy the file.
+:pr:`413` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 `ramp-engine`
 .............
 

--- a/ramp-database/ramp_database/model/submission.py
+++ b/ramp-database/ramp_database/model/submission.py
@@ -639,7 +639,8 @@ class SubmissionFile(Model):
 
     @property
     def is_editable(self):
-        """bool: Whether the submission file is from an editable format."""
+        """bool: Whether the submission file is from an editable format on the
+        frontend."""
         return self.workflow_element.is_editable
 
     @property
@@ -754,7 +755,7 @@ class SubmissionFileType(Model):
     name : str
         The name of the submission file type.
     is_editable : bool
-        Whether or not this type of file is editable.
+        Whether or not this type of file is editable on the frontend.
     max_size : int
         The maximum size of this file type.
     workflow_element_types : list of \

--- a/ramp-database/ramp_database/model/workflow.py
+++ b/ramp-database/ramp_database/model/workflow.py
@@ -57,7 +57,8 @@ class WorkflowElementType(Model):
 
     @property
     def is_editable(self):
-        """bool: Whether or not the submission file is an editable type."""
+        """bool: Whether or not the submission file is an editable type on the
+        frontend."""
         return self.type.is_editable
 
     @property
@@ -180,7 +181,8 @@ class WorkflowElement(Model):
 
     @property
     def is_editable(self):
-        """bool: Whether or not the submission file is an editable type."""
+        """bool: Whether or not the submission file is an editable type on the
+        frontend."""
         return self.workflow_element_type.is_editable
 
     @property

--- a/ramp-database/ramp_database/tools/submission.py
+++ b/ramp-database/ramp_database/tools/submission.py
@@ -181,24 +181,20 @@ def add_submission(session, event_name, team_name, submission_name,
             event.set_n_submissions()
 
     def is_editable(filename, workflow):
+        """Whether or not the file format is editable on the frontend."""
         for element in workflow.elements:
             if element.name in filename:
                 return element.is_editable
         return True
 
     # copy the submission file in the submission folder
-    # For files that are not editable, only create a symlink to avoid
-    # duplicating large datafiles
     if os.path.exists(submission.path):
         shutil.rmtree(submission.path)
     os.makedirs(submission.path)
     for filename in submission.f_names:
         src = os.path.join(submission_path, filename)
         dst = os.path.join(submission.path, filename)
-        if is_editable(filename, event.problem.workflow):
-            shutil.copy2(src=src, dst=dst)
-        else:
-            os.symlink(src, dst)
+        shutil.copy2(src=src, dst=dst)
 
     # for remembering it in the sandbox view
     event_team.last_submission_name = submission_name

--- a/ramp-frontend/ramp_frontend/views/ramp.py
+++ b/ramp-frontend/ramp_frontend/views/ramp.py
@@ -888,14 +888,9 @@ def view_model(submission_hash, f_name):
                 name=filename.split('.')[0], workflow=event.workflow).one()
 
             # TODO: deal with different extensions of the same file
-            # For non-editable files, only create a symlink if the file
-            # does not already exist.
             src = os.path.join(submission.path, filename)
             dst = os.path.join(sandbox_submission.path, filename)
-            if workflow_element.is_editable:
-                shutil.copy2(src, dst)  # copying also metadata
-            elif not os.path.exists(dst):
-                os.symlink(src, dst)
+            shutil.copy2(src, dst)  # copying also metadata
             logger.info('Copying {} to {}'.format(src, dst))
 
             submission_file = SubmissionFile.query.filter_by(


### PR DESCRIPTION
closes #409 

Always make a copy instead of trying to symlink. We should go from the principle that the data are always quite small.