### PR TITLE
Use psycopg2-binary

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -28,12 +28,12 @@ The dependencies required by the RAMP bundle are the following:
     * nbconvert
     * numpy
     * pandas
-    * psycopg2
+    * psycopg2-binary
     * sqlalchemy
 2. ``ramp-engine``:
     * click
     * numpy
-    * psycopg2
+    * psycopg2-binary
     * sqlalchemy
 3. ``ramp-frontend``:
     * bokeh

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pyyaml
   - pytest
   - pytest-cov
-  - psycopg2
+  - psycopg2-binary
   - scikit-image
   - sqlalchemy
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -18,11 +18,11 @@ dependencies:
   - pyyaml
   - pytest
   - pytest-cov
-  - psycopg2-binary
   - scikit-image
   - sqlalchemy
   - pip:
     - codecov
     - ramp-workflow
+    - psycopg2-binary
     - Flask-Mail
     - Flask-Wtf  # install from conda default channel when 0.14.3 is available

--- a/ramp-database/setup.py
+++ b/ramp-database/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7']
 INSTALL_REQUIRES = ['bcrypt', 'click', 'gitpython', 'nbconvert', 'numpy',
-                    'pandas', 'psycopg2', 'sqlalchemy']
+                    'pandas', 'psycopg2-binary', 'sqlalchemy']
 EXTRAS_REQUIRE = {
     'tests': ['pytest', 'pytest-cov'],
     'docs': ['sphinx', 'sphinx_rtd_theme', 'numpydoc']

--- a/ramp-engine/setup.py
+++ b/ramp-engine/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Operating System :: MacOS',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7']
-INSTALL_REQUIRES = ['click', 'numpy', 'psycopg2', 'sqlalchemy']
+INSTALL_REQUIRES = ['click', 'numpy', 'psycopg2-binary', 'sqlalchemy']
 EXTRAS_REQUIRE = {
     'tests': ['pytest', 'pytest-cov'],
     'docs': ['sphinx', 'sphinx_rtd_theme', 'numpydoc']

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ scikit-image
 pytest
 pytest-cov
 pyyaml
-psycopg2
+psycopg2-binary
 sqlalchemy


### PR DESCRIPTION
Update dependency to psycopg2-binary instead of psycopg2.

For reference, this is the error you get with psycopg2:
```
   ERROR: Command errored out with exit status 1:
     command: /home/lucy/miniconda3/envs/test/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-fw2xgs5r/psycopg2/setup.py'"'"'; __file__='"'"'/tmp/pip-install-fw2xgs5r/psycopg2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-fw2xgs5r/psycopg2/pip-egg-info
         cwd: /tmp/pip-install-fw2xgs5r/psycopg2/
    Complete output (23 lines):
    running egg_info
    creating /tmp/pip-install-fw2xgs5r/psycopg2/pip-egg-info/psycopg2.egg-info
    writing /tmp/pip-install-fw2xgs5r/psycopg2/pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to /tmp/pip-install-fw2xgs5r/psycopg2/pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to /tmp/pip-install-fw2xgs5r/psycopg2/pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file '/tmp/pip-install-fw2xgs5r/psycopg2/pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    
    Error: pg_config executable not found.
    
    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:
    
        python setup.py build_ext --pg-config /path/to/pg_config build ...
    
    or with the pg_config option in 'setup.cfg'.
    
    If you prefer to avoid building psycopg2 from source, please install the PyPI
    'psycopg2-binary' package instead.
    
    For further information please check the 'doc/src/install.rst' file (also at
    <http://initd.org/psycopg/docs/install.html>).
    
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```