### PR TITLE
BUG Fix aws connection failure

### DIFF
--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -138,6 +138,7 @@ def launch_ec2_instances(config, nb=1):
         ]
     }]
     sess = _get_boto_session(config)
+    client = sess.client('ec2')
     resource = sess.resource('ec2')
     instances = resource.create_instances(
         ImageId=ami_image_id,
@@ -148,6 +149,9 @@ def launch_ec2_instances(config, nb=1):
         TagSpecifications=tags,
         SecurityGroups=[security_group],
     )
+    # Wait until AMI is okay
+    waiter = client.get_waiter('instance_status_ok')
+    waiter.wait(InstanceIds=ami_image_id)
     return instances
 
 

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -151,7 +151,7 @@ def launch_ec2_instances(config, nb=1):
     )
     # Wait until AMI is okay
     waiter = client.get_waiter('instance_status_ok')
-    waiter.wait(InstanceIds=ami_image_id)
+    waiter.wait(InstanceIds=[instance.id for instance in instances])
     return instances
 
 


### PR DESCRIPTION
When the worker connects to the aws instance, if the ssh connection is not able to be established in 5 tries, the submission fails.

This PR tries to use [`EC2.Waiter.InstanceStatusOk`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Waiter.InstanceStatusOk) from boto3