### PR TITLE
BUG Add wait between status checks AWS worker

### DIFF
--- a/doc/create_ramp_event.rst
+++ b/doc/create_ramp_event.rst
@@ -78,8 +78,9 @@ The ``config.yml`` file should look like::
 * ``n_workers``: Maximum number of workers that can run submissions
   simultaneously.
 * ``n_threads``: The number of threads that each worker can use.
-* ``status_check_wait``: How long, in seconds, the worker should wait before
-  re-checking if the submission has finished training. The default is 1 second.
+* ``time_between_collection``: How long, in seconds, the worker should wait
+  before re-checking if the submission is ready for collection. The default is
+  1 second.
 
 Before you continue make sure that:
 

--- a/doc/create_ramp_event.rst
+++ b/doc/create_ramp_event.rst
@@ -6,10 +6,10 @@ Set up a new RAMP event
 Deploy a specific RAMP event
 ----------------------------
 
-Now we will want to deploy a specific problem and event. We will take an
-example by deploying an ``iris`` event.
+Now we want to deploy a specific problem and event. We will demonstrate by
+by deploying an ``iris`` event.
 
-First, you need to get the starting kit and the data within the
+First, you need to get the starting kit and the data into the
 ``ramp_deployment`` directory::
 
     ~/ramp_deployment $ mkdir ramp-kits
@@ -30,7 +30,7 @@ The above creates a ``events/iris_test`` directory inside the deployment
 directory, and populates it with a ``config.yml`` with the configuration
 specific to the event.
 
-This config file should look like::
+The ``config.yml`` file should look like::
 
     ramp:
         problem_name: iris
@@ -45,14 +45,41 @@ This config file should look like::
         n_workers: 2
         n_threads: 2
 
-.. note::
-    - <event_name> must always be preceded with the '<problem_name>_' as in
-      the example above.
-    - In the previous configuration example, we are using a conda worker. You
-      can refer to the documentation about the :ref:`workers <all_workers>` and
-      more precisely the :ref:`conda workers <conda_env_worker>` to have more
-      information.
+**ramp configuration**
 
+* ``problem_name``: All events using the same problem should have the same
+  ``problem_name``.
+* ``event_name``: Must always be preceded with '<problem_name>_' as in
+  the example above.
+* ``event_title``: Human readable event name to display on website.
+* ``event_is_public``: Boolean indication whether or not the event should be
+  public.
+
+**worker configuration**
+
+* ``worker_type``: Refer to the documentation about
+  :ref:`workers <all_workers>` for more information on worker types available.
+* ``conda_env``: Name of the conda environment to use. If not specified, the
+  base environment will be used. Only relevant if using a conda worker.
+
+.. _dispatcher_configuration:
+
+**dispatcher configuration**
+
+* ``hunger_policy``: Policy to apply in case that there is no anymore workers
+  to be processed. One of `None`, 'sleep' or 'exit', default is `None`:
+
+    * if `None`: the dispatcher will work without interruption;
+    * if 'sleep': the dispatcher will sleep for 5 seconds before to check
+      for new submission;
+    * if 'exit': the dispatcher will stop after collecting the results of
+      the last submissions.
+
+* ``n_workers``: Maximum number of workers that can run submissions
+  simultaneously.
+* ``n_threads``: The number of threads that each worker can use.
+* ``status_check_wait``: How long, in seconds, the worker should wait before
+  re-checking if the submission has finished training. The default is 1 second.
 
 Before you continue make sure that:
 
@@ -65,14 +92,14 @@ Before you continue make sure that:
 
         Note:
 
-        - for more information on directory structure of the starting kits check
+        - for more information on directory structure of the starting kits see
           `Overall directory structure
           <https://paris-saclay-cds.github.io/ramp-docs/ramp-workflow/dev/workflow.html#overall-directory-structure>`_
 
     2.  The conda environment (set in the ``config.yml`` file above, here
         called `ramp-iris`) used by your event exists. Note, that this only
-        applies to the events which use the conda environment. To check which conda
-        environments you have type::
+        applies to events that use the conda worker. To check which conda
+        environments are available, use::
 
         $ conda env list
 
@@ -82,10 +109,10 @@ database) by calling from the deployment directory::
     ~/ramp_deployment $ ramp setup deploy-event --event-config events/iris_test/config.yml --no-cloning
 
 Without passing ``--no-cloning``, it will try to clone the starting kit and
-data from the https://github.com/ramp-kits/ github organization. If the
-starting kit is located there, you can skip the first step of above of manually
-cloning the kit and data and preparing the data, and let ``ramp setup
-deploy-event`` do that for you.
+data from the https://github.com/ramp-kits/ GitHub organization. If the
+starting kit is located on this GitHub organization, you can skip the first
+step above, which manually clones the kit and prepares the data, and let
+``ramp setup deploy-event`` do this for you.
 
 Launch the dispatcher to train and evaluate submissions
 -------------------------------------------------------

--- a/doc/workers.rst
+++ b/doc/workers.rst
@@ -195,7 +195,7 @@ Create an event config.yml (see :ref:`deploy-ramp-event`) and update the
           hunger_policy: sleep
           n_workers: 5
           n_threads: 2
-          status_check_wait: 60
+          time_between_collection: 60
 
 **Worker configuration**
 
@@ -247,11 +247,12 @@ Create an event config.yml (see :ref:`deploy-ramp-event`) and update the
   AWS instance limit.
 * ``n_threads``: The number of threads that each worker can use. This would
   depend on the AWS instance type you have choosen.
-* ``status_check_wait``: How long, in seconds, the worker should wait before
-  re-checking if the submission has finished training. The default is 1 second.
-  For AWS workers this means that a request would be sent every second, which
-  can sometimes cause the worker to hang. We advise to set this configuration
-  to at least 60 seconds.
+* ``time_between_collection``: How long, in seconds, the worker should wait
+  before re-checking if the submission is ready for collection. The default is
+  1 second. For AWS workers the check for collection will be done through SSH.
+  If the time between checks is too small, the repetitive SSH requests may be
+  potentially blocked by the cloud provider. We advise to set this
+  configuration to at least 60 seconds.
 
 Create your own worker
 ----------------------

--- a/doc/workers.rst
+++ b/doc/workers.rst
@@ -165,7 +165,7 @@ instance <https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guid
 for more details.
 
 Event configuration
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 
 Create an event config.yml (see :ref:`deploy-ramp-event`) and update the
 'worker' section, which should look something like::
@@ -191,6 +191,13 @@ Create an event config.yml (see :ref:`deploy-ramp-event`) and update the
           predictions_dir: /home/ramp/ramp_deployment/events/iris_aws/predictions
           logs_dir: /home/ramp/ramp_deployment/events/iris_aws/logs
           memory_profiling: false
+      dispatcher:
+          hunger_policy: sleep
+          n_workers: 5
+          n_threads: 2
+          status_check_wait: 60
+
+**Worker configuration**
 
 * ``access_key_id`` and ``secret_access_key``: to create a new access key, go
   to your top navigation bar, click on your user name -> My Security
@@ -228,6 +235,23 @@ Create an event config.yml (see :ref:`deploy-ramp-event`) and update the
   submission. You need to install `memory profiler
   <https://pypi.org/project/memory-profiler/>`_ in your prepared AMI image
   to enable this.
+
+.. _AWS_dispatcher:
+
+**Dispatcher configuration**
+
+* ``hunger_policy``: See :ref:`dispatcher_configuration`.
+* ``n_workers``: Maximum number of workers that can run submissions
+  simultaneously. For AWS workers, this means the maximum number of
+  instances that can be run at one time. This should fall within your
+  AWS instance limit.
+* ``n_threads``: The number of threads that each worker can use. This would
+  depend on the AWS instance type you have choosen.
+* ``status_check_wait``: How long, in seconds, the worker should wait before
+  re-checking if the submission has finished training. The default is 1 second.
+  For AWS workers this means that a request would be sent every second, which
+  can sometimes cause the worker to hang. We advise to set this configuration
+  to at least 60 seconds.
 
 Create your own worker
 ----------------------

--- a/ramp-engine/ramp_engine/aws/worker.py
+++ b/ramp-engine/ramp_engine/aws/worker.py
@@ -137,7 +137,7 @@ class AWSWorker(BaseWorker):
                 self.status = 'finished'
             if self.status != 'finished':
                 raise ValueError("Cannot collect results if worker is not"
-                                "'running' or 'finished'")
+                                 "'running' or 'finished'")
 
         logger.info("Collecting submission '{}'".format(self.submission))
         aws.download_log(self.config, self.instance.id, self.submission)

--- a/ramp-engine/ramp_engine/aws/worker.py
+++ b/ramp-engine/ramp_engine/aws/worker.py
@@ -127,7 +127,8 @@ class AWSWorker(BaseWorker):
         dt = self.time_since_last_status_check()
         min_wait = self.config.get('check_finished_training_interval_secs', 1)
         wait_longer = False if dt is None else dt < min_wait
-        logger.info(f'XXXX dt:{dt} min_wait:{min_wait} XXXX')
+        logger.info(f'check_finished_training_interval_secs: '
+                    f'dt:{dt} min_wait:{min_wait}')
         if wait_longer:
             time.sleep(min_wait)
         else:

--- a/ramp-engine/ramp_engine/aws/worker.py
+++ b/ramp-engine/ramp_engine/aws/worker.py
@@ -124,7 +124,7 @@ class AWSWorker(BaseWorker):
             self.status = 'finished'
         if self.status != 'finished':
             raise ValueError("Cannot collect results if worker is not"
-                                "'running' or 'finished'")
+                             "'running' or 'finished'")
 
         logger.info("Collecting submission '{}'".format(self.submission))
         aws.download_log(self.config, self.instance.id, self.submission)

--- a/ramp-engine/ramp_engine/base.py
+++ b/ramp-engine/ramp_engine/base.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from datetime import datetime
 from abc import ABCMeta, abstractmethod
 

--- a/ramp-engine/ramp_engine/base.py
+++ b/ramp-engine/ramp_engine/base.py
@@ -81,6 +81,10 @@ class BaseWorker(metaclass=ABCMeta):
         """Check a submission for timeout."""
         pass
 
+    def time_last_status_check(self):
+        """Calculate how long the last status check was, in seconds."""
+        pass
+
     @abstractmethod
     def launch_submission(self):
         """Launch a submission to be trained."""

--- a/ramp-engine/ramp_engine/base.py
+++ b/ramp-engine/ramp_engine/base.py
@@ -71,7 +71,7 @@ class BaseWorker(metaclass=ABCMeta):
     def status(self):
         status = self._status
         if status == 'running':
-            self._status_check_time_ = datetime.utcnow()
+            self._status_check_time = datetime.utcnow()
             if self._is_submission_finished():
                 self._status = 'finished'
         return self._status
@@ -86,9 +86,9 @@ class BaseWorker(metaclass=ABCMeta):
 
     def time_since_last_status_check(self):
         """Calculate how long the last status check was, in seconds."""
-        if not hasattr(self, "_status_check_time_"):
+        if not hasattr(self, "_status_check_time"):
             return None
-        dt = (datetime.utcnow() - self._status_check_time_).total_seconds()
+        dt = (datetime.utcnow() - self._status_check_time).total_seconds()
         return dt
 
     @abstractmethod

--- a/ramp-engine/ramp_engine/base.py
+++ b/ramp-engine/ramp_engine/base.py
@@ -1,4 +1,6 @@
 import logging
+import time
+from datetime import datetime
 from abc import ABCMeta, abstractmethod
 
 logger = logging.getLogger('RAMP-WORKER')
@@ -69,6 +71,7 @@ class BaseWorker(metaclass=ABCMeta):
     def status(self):
         status = self._status
         if status == 'running':
+            self._status_check_time_ = datetime.utcnow()
             if self._is_submission_finished():
                 self._status = 'finished'
         return self._status
@@ -81,9 +84,12 @@ class BaseWorker(metaclass=ABCMeta):
         """Check a submission for timeout."""
         pass
 
-    def time_last_status_check(self):
+    def time_since_last_status_check(self):
         """Calculate how long the last status check was, in seconds."""
-        pass
+        if not hasattr(self, "_status_check_time_"):
+            return None
+        dt = (datetime.utcnow() - self._status_check_time_).total_seconds()
+        return dt
 
     @abstractmethod
     def launch_submission(self):

--- a/ramp-engine/ramp_engine/base.py
+++ b/ramp-engine/ramp_engine/base.py
@@ -1,6 +1,6 @@
 import logging
-from datetime import datetime
 from abc import ABCMeta, abstractmethod
+from datetime import datetime
 
 logger = logging.getLogger('RAMP-WORKER')
 
@@ -70,7 +70,7 @@ class BaseWorker(metaclass=ABCMeta):
     def status(self):
         status = self._status
         if status == 'running':
-            self._status_check_time = datetime.utcnow()
+            self._status_running_check_time = datetime.utcnow()
             if self._is_submission_finished():
                 self._status = 'finished'
         return self._status
@@ -84,11 +84,22 @@ class BaseWorker(metaclass=ABCMeta):
         pass
 
     def time_since_last_status_check(self):
-        """Calculate how long the last status check was, in seconds."""
-        if not hasattr(self, "_status_check_time"):
+        """Calculate time elapsed since the last 'running' status check, in
+        seconds.
+
+        Returns
+        -------
+        elapsed_time : int or None
+            Time elapsed in seconds since the last 'running' status
+            check. If `_status_running_check_time` attribute does not
+            exist (e.g. `worker.status` has not been called once status
+            is 'running'), `None` is returned.
+        """
+        if not hasattr(self, "_status_running_check_time"):
             return None
-        dt = (datetime.utcnow() - self._status_check_time).total_seconds()
-        return dt
+        elapsed_time = ((datetime.utcnow() -
+                        self._status_running_check_time).total_seconds())
+        return elapsed_time
 
     @abstractmethod
     def launch_submission(self):

--- a/ramp-engine/ramp_engine/cli.py
+++ b/ramp-engine/ramp_engine/cli.py
@@ -79,10 +79,12 @@ def dispatcher(config, event_config, verbose):
     n_workers = dispatcher_config.get('n_workers', -1)
     n_threads = dispatcher_config.get('n_threads', None)
     hunger_policy = dispatcher_config.get('hunger_policy', 'sleep')
+    status_check_wait = dispatcher_config.get('status_check_wait', 1)
 
     disp = Dispatcher(
         config=config, event_config=event_config, worker=worker_type,
-        n_workers=n_workers, n_threads=n_threads, hunger_policy=hunger_policy
+        n_workers=n_workers, n_threads=n_threads, hunger_policy=hunger_policy,
+        status_check_wait=status_check_wait
     )
     disp.launch()
 

--- a/ramp-engine/ramp_engine/cli.py
+++ b/ramp-engine/ramp_engine/cli.py
@@ -79,12 +79,13 @@ def dispatcher(config, event_config, verbose):
     n_workers = dispatcher_config.get('n_workers', -1)
     n_threads = dispatcher_config.get('n_threads', None)
     hunger_policy = dispatcher_config.get('hunger_policy', 'sleep')
-    status_check_wait = dispatcher_config.get('status_check_wait', 1)
+    time_between_collection = dispatcher_config.get(
+        'time_between_collection', 1)
 
     disp = Dispatcher(
         config=config, event_config=event_config, worker=worker_type,
         n_workers=n_workers, n_threads=n_threads, hunger_policy=hunger_policy,
-        status_check_wait=status_check_wait
+        time_between_collection=time_between_collection
     )
     disp.launch()
 

--- a/ramp-engine/ramp_engine/dispatcher.py
+++ b/ramp-engine/ramp_engine/dispatcher.py
@@ -183,10 +183,10 @@ class Dispatcher:
                                                             submissions):
             dt = worker.time_since_last_status_check()
             wait_longer = (False if dt is None else
-                            dt < self.status_check_wait)
+                           dt < self.status_check_wait)
             if wait_longer:
                 self._processing_worker_queue.put_nowait(
-                (worker, (submission_id, submission_name)))
+                    (worker, (submission_id, submission_name)))
                 time.sleep(0)
                 continue
             if worker.status == 'running':

--- a/ramp-engine/ramp_engine/dispatcher.py
+++ b/ramp-engine/ramp_engine/dispatcher.py
@@ -7,8 +7,6 @@ import time
 from queue import Queue
 from queue import LifoQueue
 
-import numpy as np
-
 from ramp_database.tools.submission import get_submissions
 from ramp_database.tools.submission import get_submission_by_id
 from ramp_database.tools.submission import get_submission_state
@@ -188,7 +186,7 @@ class Dispatcher:
                             dt < self.status_check_wait)
             if wait_longer:
                 self._processing_worker_queue.put_nowait(
-                    (worker, (submission_id, submission_name)))
+                (worker, (submission_id, submission_name)))
                 time.sleep(0)
                 continue
             if worker.status == 'running':

--- a/ramp-utils/ramp_utils/template/ramp_config_template.yml
+++ b/ramp-utils/ramp_utils/template/ramp_config_template.yml
@@ -15,4 +15,5 @@ worker:
 dispatcher:
     hunger_policy: sleep
     # n_workers: (number of RAMP workers launched in parallel. Default: # CPUs)
-    # n_threads: (number of threads used by a RAMP worker: Default: # CPUs)
+    # n_threads: (number of threads used by a RAMP worker. Default: # CPUs)
+    # time_between_collection: (how long to wait before re-checking if submission finished. Default: 1s)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Currently `_has_screen` is run every few seconds, during status checks, and is (most likely) causing AWS worker to hang. 

https://github.com/paris-saclay-cds/ramp-board/blob/7e975d01c080278b2101a5ca48461bc7e5dcd3ea/ramp-engine/ramp_engine/aws/api.py#L713-L721

AWS worker hangs (>50% of the time) with the last log being:
> 2020-10-14 21:37:49,621 RAMP-AWS DEBUG ssh -o 'StrictHostKeyChecking no' -i /home/lucy/Documents/RAMP/ramp-board/ramp-deployment/aws_ramp_ireland.pem ubuntu@34.242.228.66 "screen -ls|awk '{print $1}' | cut -d. -f2 | grep submission_000000022| wc -l"

which is generally run ~20 or more times.

This uses the dispatcher config ~`check_finished_training_interval_secs`:~ `status_check_wait`
to add a wait time between status checks. The default wait time is 1s.

TODO:

* Add test
* Add documentation

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
