### PR TITLE
MNT add email_validator which is required with latest release of flask-email

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,3 +27,4 @@ dependencies:
     - Flask-Mail
     - Flask-Wtf  # install from conda default channel when 0.14.3 is available
     - wtforms[email]
+    - email_validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ bokeh
 boto3
 click
 codecov
+email_validator
 flake8
 Flask
 Flask-Login


### PR DESCRIPTION
While updating the production server, I needed to install `email_validator` by hand.
I just added it to the list of the dependencies to be sure that it would be installed as well.