### PR TITLE
ADV/STY Round train/test times to ms in the leaderboard

### DIFF
--- a/ramp-database/ramp_database/tools/leaderboard.py
+++ b/ramp-database/ramp_database/tools/leaderboard.py
@@ -88,6 +88,8 @@ def _compute_leaderboard(session, submissions, leaderboard_type, event_name,
 
         # add the aggregated time information
         df_time.index = df.index
+        for key in ['train', 'valid', 'test']:
+            df_time[key] = df_time[key].round(3)
         df_time = df_time.rename(
             columns={'train': 'train time [s]',
                      'valid': 'validation time [s]',


### PR DESCRIPTION
Minor styling fix from https://github.com/paris-saclay-cds/ramp-board/pull/276/

PR to `advanced` but can be also backported to `master`

Rounds the timing shown in the leaderboard to ms, currently they are in rounded to µs (which is not relevant and probably  larger than the measurement error)
