### PR TITLE
ADV Mechanism for custom sign up instructions + privacy page

### DIFF
--- a/doc/personalize.rst
+++ b/doc/personalize.rst
@@ -1,10 +1,10 @@
-###################################
-Personalize your RAMP front webpage
-###################################
+##############################
+Personalize your RAMP instance
+##############################
 
 It is possible to personalize your RAMP front page.
 
-Powered by
+Front page
 ----------
 You might be interested in displaying some images (logos) in the ``Powered by``
 section in the very bottom of your RAMP webpage.
@@ -22,3 +22,42 @@ Your images must have one of the following extensions:
 * .svg
 
 When you reload your RAMP page the new ``Powered by`` section should appear.
+
+
+Privacy Policy page
+-------------------
+
+You can add an optional Privacy Policy page, setting the following in the main
+`config.yaml`,
+
+.. code::
+
+    flask:
+        ...
+        privacy_policy_page: "<path.html>"
+
+Where the ``privacy_policy_page`` can be either a path to an HTML file, or
+directly the HTML contents of that page.
+
+This will enable the ``/privacy_policy`` endpoint, and will add it to the footer
+menu.
+
+
+Sign up and login pages
+-----------------------
+
+You can add personalized messages to the Sign Up and Login pages, as follows,
+
+.. code::
+
+    flask:
+        ...
+        login_instructions: "instructions A"
+        sign_up_instructions: "instructions A"
+        sign_up_ask_social_media: True    # ask for social media acounts (optional)
+
+where ``login_instructions`` and ``sign_up_instructions`` can be either a path to an HTML
+file, or directly the HTML contents.
+
+By including HTML code with JavaScripts, these field can also be used to customize the
+Sign Up and Login forms.

--- a/doc/personalize.rst
+++ b/doc/personalize.rst
@@ -59,5 +59,5 @@ You can add personalized messages to the Sign Up and Login pages, as follows,
 where ``login_instructions`` and ``sign_up_instructions`` can be either a path to an HTML
 file, or directly the HTML contents.
 
-By including HTML code with JavaScripts, these field can also be used to customize the
+By including HTML code with JavaScript, these field can also be used to customize the
 Sign Up and Login forms.

--- a/ramp-frontend/ramp_frontend/static/css/style.css
+++ b/ramp-frontend/ramp_frontend/static/css/style.css
@@ -278,6 +278,9 @@ a:hover {
   line-height: 50px;
   vertical-align: middle;
 }
+.app-footer .wrapper > span {
+  margin-right: 20px;
+}
 .app-container .content-container {
   margin-right: 0;
   margin-left: 0;

--- a/ramp-frontend/ramp_frontend/static/css/style.css
+++ b/ramp-frontend/ramp_frontend/static/css/style.css
@@ -278,7 +278,7 @@ a:hover {
   line-height: 50px;
   vertical-align: middle;
 }
-.app-footer .wrapper > span {
+.app-footer span {
   margin-right: 20px;
 }
 .app-container .content-container {
@@ -881,6 +881,12 @@ div.info-header {
 .checkbox-inline,
 .radio-inline {
   font-weight: normal;
+}
+
+.container-fluid .checkbox input[type=checkbox] {
+  /* Overwriting  value set in forms.less to -20px;
+     as Sign Up form doesn't render well otherwise */
+  margin-left: 0px;
 }
 
 .bootstrap-switch {

--- a/ramp-frontend/ramp_frontend/templates/base.html
+++ b/ramp-frontend/ramp_frontend/templates/base.html
@@ -20,6 +20,8 @@
     <!-- CSS App -->
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/themes/flat-blue.css') }}">
+
+    <script type="text/javascript" src="{{ url_for('static', filename='lib/js/jquery.min.js') }}"></script>
     {% endblock %}
     <script>
         (function (i, s, o, g, r, a, m) {
@@ -236,7 +238,7 @@
                 <span><a href="/"><img src="{{ url_for('static', filename='img/logo_CDS_footer.svg') }}"
                             height="20px"></a></span> &nbsp; &nbsp; &nbsp; &nbsp; <span><a
                         href="mailto:admin@ramp.studio">Contact Us <i class="icon fa fa-envelope"></i></a></span>
-	        {% if config['PRIVACY_PAGE'] %}
+	        {% if config['PRIVACY_POLICY_PAGE'] %}
 	        <span>
 		  <a href='/privacy_policy'>Privacy policy</a> 
 		</span>
@@ -244,7 +246,6 @@
             </div>
         </footer>
         <div>
-            <script type="text/javascript" src="{{ url_for('static', filename='lib/js/jquery.min.js') }}"></script>
             <script type="text/javascript" src="{{ url_for('static', filename='lib/js/bootstrap.min.js') }}"></script>
             <script type="text/javascript" src="{{ url_for('static', filename='lib/js/Chart.min.js') }}"></script>
             <script type="text/javascript"

--- a/ramp-frontend/ramp_frontend/templates/base.html
+++ b/ramp-frontend/ramp_frontend/templates/base.html
@@ -236,6 +236,11 @@
                 <span><a href="/"><img src="{{ url_for('static', filename='img/logo_CDS_footer.svg') }}"
                             height="20px"></a></span> &nbsp; &nbsp; &nbsp; &nbsp; <span><a
                         href="mailto:admin@ramp.studio">Contact Us <i class="icon fa fa-envelope"></i></a></span>
+	        {% if config['PRIVACY_PAGE'] %}
+	        <span>
+		  <a href='/privacy_policy'>Privacy policy</a> 
+		</span>
+		{% endif %}
             </div>
         </footer>
         <div>

--- a/ramp-frontend/ramp_frontend/templates/index.html
+++ b/ramp-frontend/ramp_frontend/templates/index.html
@@ -221,6 +221,11 @@
       <div class="container">
           <center><span class="pull-left"><i class="icon fa fa-copyright"></i> RAMP version {{ version }} <a href="#"><i class="icon fa fa-long-arrow-up"></i><i class="icon fa fa-long-arrow-up"></i></a></span> &nbsp; &nbsp; &nbsp; &nbsp;
           <span><a href="/"><img src="{{ url_for('static', filename='img/logo_CDS_footer.svg') }}" height="20px"></a></span> &nbsp; &nbsp; &nbsp; &nbsp; <span><a href="mailto:admin@ramp.studio">Contact Us <i class="icon fa fa-envelope"></i></a></span>
+	{% if config['PRIVACY_POLICY_PAGE'] %}
+	<span>
+	  <a href='/privacy_policy'>Privacy policy</a>
+	</span>
+	{% endif %}
           <span class="pull-right">Thanks to <a href="https://github.com/tui2tone/flat-admin-bootstrap-templates" target="_blank">tui2tone</a> for the  template!</span>
           </center>
       </div>

--- a/ramp-frontend/ramp_frontend/templates/login.html
+++ b/ramp-frontend/ramp_frontend/templates/login.html
@@ -60,12 +60,9 @@
           Forgot your password? <a href="/reset_password">Reset it!</a>
         </div>
       </form>
-      <p>
-        Consider joining our
-        <a href="https://ramp-studio.slack.com/shared_invite/MTg1NDUxNDAyNDk2LTE0OTUzOTcwMDQtMThlOWY1NWU0Mg"><strong>slack
-            team</strong></a>
-        if you would like to be part of the growing community of rampers.
-      </p>
+      <div class="login-page-instructions">
+	{{ config['LOGIN_INSTRUCTIONS'] | safe }}
+      </div>
     </div>
   </div>
 </div>

--- a/ramp-frontend/ramp_frontend/templates/privacy_policy.html
+++ b/ramp-frontend/ramp_frontend/templates/privacy_policy.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %} {% block title %}Privacy policy{% endblock %}
+{% block content %}
+{{ config['PRIVACY_POLICY_PAGE'] | safe }}
+{% endblock %}

--- a/ramp-frontend/ramp_frontend/templates/sign_up.html
+++ b/ramp-frontend/ramp_frontend/templates/sign_up.html
@@ -79,15 +79,18 @@
           {% endfor %}
         </div>
         <div class="checkbox">
-          {{ form.is_want_news(placeholder="is_want_news", checked=True) }}
+          {{ form.is_want_news(placeholder="is_want_news", checked=False) }}
           <label>I would like to receive news about future RAMP events</label>
           {% for error in form.is_want_news.errors %}
           <span style="color: red;">[{{ error }}]</span>
           {% endfor %}
         </div>
-        Consider joining our <a
-          href="https://ramp-studio.slack.com/shared_invite/MTg1NDUxNDAyNDk2LTE0OTUzOTcwMDQtMThlOWY1NWU0Mg"><strong>slack
-            team</strong></a> if you would like to be part of the growing community of rampers.</font><br>
+        <div class="login-page-instructions">
+          {{ config['SIGN_UP_INSTRUCTIONS'] | safe}}
+        </div>
+
+	{% if config['SIGN_UP_ASK_SOCIAL_MEDIA'] %}
+         <br>
         <p> The following fields are not mandatory, but the more we know about you, the more likely we will
           approve your sign-up application.</p>
         <div class="form-group">
@@ -139,6 +142,7 @@
           <span style="color: red;">[{{ error }}]</span>
           {% endfor %}
         </div>
+	{% endif %}
         <input type="submit" value="Sign up" class="ui submit button">
     </div>
     </form>

--- a/ramp-frontend/ramp_frontend/views/general.py
+++ b/ramp-frontend/ramp_frontend/views/general.py
@@ -1,5 +1,7 @@
+import flask
 from flask import Blueprint
 from flask import render_template
+from flask import current_app as app
 import flask_login
 import os as os
 
@@ -69,3 +71,11 @@ def keywords(keyword_name):
         return render_template('keyword.html', keyword=keyword)
     return redirect_to_user('Keyword {} does not exist.'
                             .format(keyword_name), is_error=True)
+
+
+@mod.route("/privacy_policy")
+def privacy_policy():
+    if not app.config['PRIVACY_POLICY_PAGE']:
+        flask.abort(404)
+
+    return render_template('privacy_policy.html')

--- a/ramp-utils/ramp_utils/frontend.py
+++ b/ramp-utils/ramp_utils/frontend.py
@@ -9,7 +9,23 @@ DEFAULT_CONFIG = {
     'TRACK_USER_INTERACTION': False,
     'TRACK_CREDITS': True,
     'DOMAIN_NAME': 'localhost',
+    'LOGIN_INSTRUCTIONS': None,
+    'SIGN_UP_INSTRUCTIONS': None,
+    'SIGN_UP_ASK_SOCIAL_MEDIA': False,
+    'PRIVACY_POLICY_PAGE': None
 }
+
+
+def _read_if_html_path(txt: str) -> str:
+    """Open HTML file if path provided
+
+    If the input is a path to a valid HTML file, read it.
+    Otherwise return the input
+    """
+    if txt and txt.endswith('.html'):
+        with open(txt, 'rt') as fh:
+            txt = fh.read()
+    return txt
 
 
 def generate_flask_config(config):
@@ -32,6 +48,10 @@ def generate_flask_config(config):
     user_flask_config = {
         key.upper(): value for key, value in config['flask'].items()}
     flask_config.update(user_flask_config)
+
+    for key in ['LOGIN_INSTRUCTIONS', 'SIGN_UP_INSTRUCTIONS',
+                'PRIVACY_POLICY_PAGE']:
+        flask_config[key] = _read_if_html_path(flask_config[key])
 
     database_config = config['sqlalchemy']
     flask_config['SQLALCHEMY_DATABASE_URI'] = \

--- a/ramp-utils/ramp_utils/ramp.py
+++ b/ramp-utils/ramp_utils/ramp.py
@@ -109,4 +109,5 @@ def generate_ramp_config(event_config, database_config=None):
     ramp_config['ramp_kit_submissions_dir'] = os.path.join(
         ramp_config['ramp_kit_dir'], 'submissions'
     )
+
     return ramp_config

--- a/ramp-utils/ramp_utils/template/ramp_config_template.yml
+++ b/ramp-utils/ramp_utils/template/ramp_config_template.yml
@@ -9,6 +9,10 @@ ramp:
     # predictions_dir: (absolute path where to store predictions. Default: <deployment_dir>/events/event_name>/predictions)
     # logs_dir: (absolute path where to store logs. Default: <deployment_dir>/events/<event_name>/logs)
     # sandbox_dir: (name of the default submissions. Default: starting_kit)
+    # privacy_policy_page: (path or HTML contents of the privacy policy page. Default: None)
+    # login_instructions: (path or HTML contents of custom instuctions to add to the login page. Default: None)
+    # sign_up_instructions: (path or HTML contents of custom instuctions to add to the login page. Default: None)
+    # sign_up_ask_social_media: (whether add folm field to ask for social media accounts on the sign up page. Default: False)
 worker:
     worker_type: <conda or aws>
     ...

--- a/ramp-utils/ramp_utils/tests/test_frontend.py
+++ b/ramp-utils/ramp_utils/tests/test_frontend.py
@@ -4,6 +4,7 @@ from ramp_utils.testing import database_config_template
 
 from ramp_utils import read_config
 from ramp_utils import generate_flask_config
+from ramp_utils.frontend import _read_if_html_path
 
 
 @pytest.mark.parametrize(
@@ -16,13 +17,17 @@ def test_generate_flask_config(config):
     expected_config = {
         'SECRET_KEY': 'abcdefghijkl',
         'WTF_CSRF_ENABLED': True,
+        'LOGIN_INSTRUCTIONS': None,
         'LOG_FILENAME': 'None',
         'MAX_CONTENT_LENGTH': 1073741824,
+        'PRIVACY_POLICY_PAGE': None,
         'DEBUG': True,
         'TESTING': False,
         'MAIL_SERVER': 'localhost',
         'MAIL_PORT': 8025,
         'MAIL_DEFAULT_SENDER': ['RAMP admin', 'rampmailer@localhost.com'],
+        'SIGN_UP_ASK_SOCIAL_MEDIA': False,
+        'SIGN_UP_INSTRUCTIONS': None,
         'SQLALCHEMY_TRACK_MODIFICATIONS': False,
         'SQLALCHEMY_DATABASE_URI': ('postgresql://mrramp:mrramp@localhost:5432'
                                     '/databoard_test'),
@@ -31,3 +36,17 @@ def test_generate_flask_config(config):
         'DOMAIN_NAME': 'localhost'
         }
     assert flask_config == expected_config
+
+
+def test_read_if_html_path(tmpdir):
+    msg = 'some arbitrary text'
+    assert _read_if_html_path(msg) == msg
+
+    msg = 'an_ivalid_path.html'
+    with pytest.raises(FileNotFoundError):
+        _read_if_html_path(msg)
+
+    msg = str(tmpdir / 'some_file.html')
+    with open(msg, 'wt') as fh:
+        fh.write('Privacy Policy')
+    assert _read_if_html_path(msg) == 'Privacy Policy'


### PR DESCRIPTION
This adds a mechanism for providing custom sign up / login instructions (or JS code) and an optional privacy page.

Partially addresses https://github.com/paris-saclay-cds/ramp-board/issues/440

Made to the advanced branch, but I would strongly recommend back porting this to the master branch as well.

From the added docs,
```
Privacy Policy page
-------------------

You can add an optional Privacy Policy page, setting the following in the main
`config.yaml`,

.. code::

    flask:
        ...
        privacy_policy_page: "<path.html>"

Where the ``privacy_policy_page`` can be either a path to an HTML file, or
directly the HTML contents of that page.

This will enable the ``/privacy_policy`` endpoint, and will add it to the footer
menu.

Sign up and login pages
-----------------------

You can add personallized messages to the Sign Up and Login pages, as follows,

.. code::

    flask:
        ...
        login_instructions: "instructions A"
        sign_up_instructions: "instructions A"
        sign_up_ask_social_media: True    # ask for social media acounts (optional)

where ``login_instructions`` and ``sign_up_instructions`` can be either a path to an HTML
file, or directly the HTML contents.

By including HTML code with JavaScript, these field can also be used to customize the
Sign Up and Login forms.
```