### PR TITLE
ADV FIX bokeh plot on admin dashboard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: main
 
-on: [push]
+on: [pull_request]
 
 
 jobs:

--- a/ramp-frontend/ramp_frontend/templates/dashboard_submissions.html
+++ b/ramp-frontend/ramp_frontend/templates/dashboard_submissions.html
@@ -107,10 +107,10 @@
   <script>
     var training_time = {
       x: {{ timestamp_submissions| safe }},
-    y: { { training_sec } },
+    y: {{ training_sec }},
     mode: 'markers',
       type: 'scatter',
-        text: { { name_submissions | tojson | safe } },
+        text: {{ name_submissions | tojson | safe }},
     marker: {
       color: "#e84b3a",
         size: 12
@@ -119,9 +119,9 @@
   };
     var cum_submissions = {
       x: {{ timestamp_submissions| safe }},
-    y: { { cumulated_submissions | safe } },
+    y: {{ cumulated_submissions | safe }},
     type: 'scatter',
-      text: { { name_submissions | tojson | safe } },
+      text: {{ name_submissions | tojson | safe }},
     marker: {
       color: "#e3a712",
         size: 12

--- a/ramp-frontend/ramp_frontend/views/visualization.py
+++ b/ramp-frontend/ramp_frontend/views/visualization.py
@@ -164,7 +164,7 @@ def score_plot(session, event):
         pareto_df, event.official_score_type.is_lower_the_better)
     source_pareto = ColumnDataSource(pareto_df)
 
-    tools = ['pan,wheel_zoom,box_zoom,reset,previewsave,tap']
+    tools = ['pan,wheel_zoom,box_zoom,reset,save,tap']
     p = figure(plot_width=900, plot_height=600, tools=tools, title='Scores')
 
     p.circle(


### PR DESCRIPTION
 - improves bokeh 2.0+ compatibility (`previewsave` tool was replaced by `save`)
 - fix Jinja2 formatting issues in `dashboard_submissions.html`

This allows to display bokeh plots on the admin submission page again.
