### PR TITLE
MRG BUG enable use of on demand instances

### DIFF
--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -147,7 +147,7 @@ def launch_ec2_instances(config, nb=1):
     sess = _get_boto_session(config)
     client = sess.client('ec2')
     resource = sess.resource('ec2')
-    on_demand = False
+    switch_to_on_demand = False
 
     if use_spot_instance:
         logger.info('Attempting to use spot instance.')
@@ -199,7 +199,7 @@ def launch_ec2_instances(config, nb=1):
         except botocore.exceptions.WaiterError:
             logger.info('Spot instance request failed due to time out. Using '
                         'on-demand instance instead')
-            on_demand = True
+            switch_to_on_demand = True
             client.cancel_spot_instance_requests(
                 SpotInstanceRequestIds=[request_id, ]
             )
@@ -226,7 +226,7 @@ def launch_ec2_instances(config, nb=1):
             instances = [instance, ]
             instance_ids = [instance_id, ]
 
-    if on_demand or not use_spot_instance:
+    if switch_to_on_demand or not use_spot_instance:
         logger.info('Using on-demand instance.')
         instances = resource.create_instances(
             ImageId=ami_image_id,

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -126,7 +126,6 @@ def launch_ec2_instances(config, nb=1):
             'or ami_image_name')
     if ami_name:
         ami_image_id = _get_image_id(config, ami_name)
-
     instance_type = config[INSTANCE_TYPE_FIELD]
     key_name = config[KEY_NAME_FIELD]
     security_group = config[SECURITY_GROUP_FIELD]
@@ -144,6 +143,7 @@ def launch_ec2_instances(config, nb=1):
     sess = _get_boto_session(config)
     client = sess.client('ec2')
     resource = sess.resource('ec2')
+    on_demand = False
 
     if use_spot_instance:
         logger.info('Attempting to use spot instance.')
@@ -167,7 +167,6 @@ def launch_ec2_instances(config, nb=1):
         waiter = client.get_waiter('spot_instance_request_fulfilled')
         request_id = \
             response['SpotInstanceRequests'][0]['SpotInstanceRequestId']
-        on_demand = False
         try:
             waiter.wait(SpotInstanceRequestIds=[request_id, ])
         except botocore.exceptions.WaiterError:

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -42,7 +42,7 @@ def add_empty_dir(dir_name):
     )
 @mock.patch("boto3.session.Session")
 def test_launch_ec2_instances(boto_session_cls, use_spot_instance):
-    ''' 'use_spot_instance' settings run through if True or False'''
+    ''' Check 'use_spot_instance' config with None, True and False'''
     # dummy mock session
     session = boto_session_cls.return_value
     client = session.client.return_value

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -48,7 +48,7 @@ def test_launch_ec2_instances(boto_session_cls, use_spot_instance):
     describe_images = client.describe_images
     images = {"Images": [{"ImageId": 1}]}
     describe_images.return_value = images
-    config = read_config(os.path.join(HERE, 'config.yml'))
+    config = read_config(os.path.join(HERE, '_config.yml'))
 
     config['worker']['use_spot_instance'] = use_spot_instance
     launch_ec2_instances(config['worker'])


### PR DESCRIPTION
The use of on demand instances on AWS is no longer working.

This PR corrects it and adds a test
