### PR TITLE
Handle errors from AWS on creating instance

### DIFF
--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -56,7 +56,7 @@ TRAIN_LOOP_INTERVAL_SECS_FIELD = 'train_loop_interval_secs'
 MEMORY_PROFILING_FIELD = 'memory_profiling'
 
 # how long to wait for connections
-WAIT_MINUTES = 10
+WAIT_MINUTES = 0.03
 MAX_TRIES_TO_CONNECT = 6
 
 HOOKS_SECTION = 'hooks'

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -172,6 +172,7 @@ def launch_ec2_instances(config, nb=1):
                     ValidFrom=now,
                     ValidUntil=(now + request_wait),
                 )
+                break
             except botocore.exceptions.ClientError as e:
                 n_try += 1
                 if n_try < max_tries_to_connect:

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -176,6 +176,11 @@ def launch_ec2_instances(config, nb=1):
                 n_try += 1
                 if n_try < max_tries_to_connect:
                     # wait before you try again
+                    logger.warning('Not enough instances available: I am going'
+                                   f' to wait for {wait_minutes} minutes'
+                                   ' before trying again (this was'
+                                   f' {n_try}/{max_tries_to_connect} tries to'
+                                   ' connect)')
                     time.sleep(wait_minutes*60)
                 else:
                     logger.error(f'Not enough instances available: {e}')

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -56,7 +56,7 @@ TRAIN_LOOP_INTERVAL_SECS_FIELD = 'train_loop_interval_secs'
 MEMORY_PROFILING_FIELD = 'memory_profiling'
 
 # how long to wait for connections
-WAIT_MINUTES = 10
+WAIT_MINUTES = 0.03
 MAX_TRIES_TO_CONNECT = 6
 
 HOOKS_SECTION = 'hooks'
@@ -179,8 +179,8 @@ def launch_ec2_instances(config, nb=1):
                     logger.warning('Not enough instances available: I am going'
                                    f' to wait for {wait_minutes} minutes'
                                    ' before trying again (this was'
-                                   f' {n_try}/{max_tries_to_connect} tries to'
-                                   ' connect)')
+                                   f' {n_try} out of {max_tries_to_connect}'
+                                   ' tries to connect)')
                     time.sleep(wait_minutes*60)
                 else:
                     logger.error(f'Not enough instances available: {e}')

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -157,7 +157,7 @@ def launch_ec2_instances(config, nb=1):
         request_wait = timedelta(minutes=wait_minutes)
         n_try = 0
         response = None
-        while not(response) and (n_try < max_tries_to_connect):
+        for n_try in range(max_tries_to_connect):
             try:
                 response = client.request_spot_instances(
                     AvailabilityZoneGroup=config[REGION_NAME_FIELD],
@@ -172,23 +172,23 @@ def launch_ec2_instances(config, nb=1):
                     ValidFrom=now,
                     ValidUntil=(now + request_wait),
                 )
+                break
             except botocore.exceptions.ClientError as e:
-                n_try += 1
-                if n_try < max_tries_to_connect:
-                    # wait before you try again
-                    logger.warning('Not enough instances available: I am going'
-                                   f' to wait for {wait_minutes} minutes'
-                                   ' before trying again (this was'
-                                   f' {n_try} out of {max_tries_to_connect}'
-                                   ' tries to connect)')
-                    time.sleep(wait_minutes*60)
-                else:
-                    logger.error(f'Not enough instances available: {e}')
-                    return None,
+                # wait before you try again
+                logger.warning('Not enough instances available: I am going'
+                               f' to wait for {wait_minutes} minutes'
+                               ' before trying again (this was'
+                               f' {n_try} out of {max_tries_to_connect}'
+                               ' tries to connect)')
+                time.sleep(wait_minutes*60)
             except Exception as e:
                 # unknown error
                 logger.error(f'AWS worker error: {e}')
                 return None,
+        else:
+            # reached max retries
+            logger.error(f'Not enough instances available: {e}')
+            return None,
         # Wait until request fulfilled
         waiter = client.get_waiter('spot_instance_request_fulfilled')
         request_id = \

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -56,8 +56,8 @@ TRAIN_LOOP_INTERVAL_SECS_FIELD = 'train_loop_interval_secs'
 MEMORY_PROFILING_FIELD = 'memory_profiling'
 
 # how long to wait for connections
-WAIT_MINUTES = 0.03
-MAX_TRIES_TO_CONNECT = 6
+WAIT_MINUTES = 2
+MAX_TRIES_TO_CONNECT = 5
 
 HOOKS_SECTION = 'hooks'
 HOOK_START_TRAINING = 'start_training'

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -56,7 +56,7 @@ TRAIN_LOOP_INTERVAL_SECS_FIELD = 'train_loop_interval_secs'
 MEMORY_PROFILING_FIELD = 'memory_profiling'
 
 # how long to wait for connections
-WAIT_MINUTES = 0.03
+WAIT_MINUTES = 10
 MAX_TRIES_TO_CONNECT = 6
 
 HOOKS_SECTION = 'hooks'

--- a/ramp-engine/ramp_engine/aws/worker.py
+++ b/ramp-engine/ramp_engine/aws/worker.py
@@ -61,13 +61,16 @@ class AWSWorker(BaseWorker):
         logger.info("Setting up AWSWorker for submission '{}'".format(
             self.submission))
         self.instance, = aws.launch_ec2_instances(self.config)
+
         if self.instance:
             logger.info("Instance launched for submission '{}'".format(
                 self.submission))
         else:
-            logger.info("Unable to launch instance for submission "
-                        "'{}'".format(self.submission))
+            logger.error("Unable to launch instance for submission "
+                         "'{}'".format(self.submission))
             self.status = 'error'
+            return
+
         for _ in range(5):
             # try uploading the submission a few times, as this regularly fails
             exit_status = aws.upload_submission(

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -20,7 +20,7 @@ from ramp_utils.testing import ramp_config_template
 
 from .test_dispatcher import session_toy  # noqa
 
-from unittest import mock
+from unittest import mock, assertLogs
 
 HERE = os.path.dirname(__file__)
 
@@ -36,8 +36,11 @@ def add_empty_dir(dir_name):
         os.mkdir(dir_name)
 
 
+# set shorter waiting time than in the actual settings
+@mock.patch("ramp_engine.aws.api.WAIT_MINUTES", 0.03)
+@mock.patch("ramp_engine.aws.api.MAX_TRIES_TO_CONNECT", 4)
 @mock.patch("boto3.session.Session")
-def test_too_many_instances(boto_session_cls):
+def test_too_many_instances(boto_session_cls, mock_logger):
     ''' test launching more instances than limit on AWS enabled'''
     # dummy mock session
     # test that the following error is caught:
@@ -58,10 +61,41 @@ def test_too_many_instances(boto_session_cls):
     config = read_config(os.path.join(HERE, '_config.yml'))
     config['worker']['use_spot_instance'] = True
     request_spot_instances = client.request_spot_instances
-    error = botocore.exceptions.ClientError(error,
-                                            "MaxSpotInstanceCountExceeded")
-    request_spot_instances.side_effect = error
-    launch_ec2_instances(config['worker'])
+    error_max_instances = botocore.exceptions.ClientError(
+        error, "MaxSpotInstanceCountExceeded")
+    error_unhandled = botocore.exceptions.ParamValidationError(report='temp')
+    correct_response = {'SpotInstanceRequests': [{'SpotInstanceRequestId': ['temp']}]}
+
+    # test 1
+    aws_response = [error_max_instances, error_max_instances,
+                    error_max_instances, error_max_instances]
+
+    request_spot_instances.side_effect = aws_response
+
+    instance, = launch_ec2_instances(config['worker'])
+    mock_logger.error.assert_called_with("Not enough instances available")
+
+
+
+
+
+
+    assert 'Error' in instance
+
+    # test 2
+    aws_response = [error_unhandled]
+    request_spot_instances.side_effect = aws_response
+    instance, = launch_ec2_instances(config['worker'])
+    assert instance is None
+    assert 'temp' in str(message)
+    
+    # test 3
+    aws_response = [error_max_instances, error_max_instances, correct_response]
+    request_spot_instances.side_effect = aws_response
+    instance, = launch_ec2_instances(config['worker'])
+    assert instance is not None
+    # assert message is None
+
 
 
 def test_aws_worker():

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -47,7 +47,7 @@ def add_empty_dir(dir_name):
 @mock.patch("ramp_engine.aws.api.WAIT_MINUTES", 0.03)
 @mock.patch("ramp_engine.aws.api.MAX_TRIES_TO_CONNECT", 4)
 @mock.patch("boto3.session.Session")
-def test_too_many_instances(boto_session_cls, caplog,
+def test_creating_instances(boto_session_cls, caplog,
                             aws_msg_type, result_none, log_msg):
     ''' test launching more instances than limit on AWS enabled'''
     # info: caplog is a pytest fixture to collect logging info

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -51,11 +51,7 @@ def test_too_many_instances(boto_session_cls, caplog,
                             aws_msg_type, result_none, log_msg):
     ''' test launching more instances than limit on AWS enabled'''
     # info: caplog is a pytest fixture to collect logging info
-    # dummy mock session
-    # test that the following error is caught:
-    # botocore.exceptions.ClientError: An error occurred
-    # (MaxSpotInstanceCountExceeded) when calling the
-    # RequestSpotInstances operation: Max spot instance count exceeded
+    # dummy mock session of AWS
     session = boto_session_cls.return_value
     client = session.client.return_value
     describe_images = client.describe_images

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -4,6 +4,7 @@ copy the _config.yml file and rename it config.yml, then update it using the
 credentials to interact with Amazon
 
 """
+import botocore
 import logging
 import os
 import shutil
@@ -11,6 +12,7 @@ import shutil
 import pytest
 
 from ramp_database.tools.submission import get_submissions
+from ramp_engine.aws.api import launch_ec2_instances
 from ramp_engine import Dispatcher, AWSWorker
 from ramp_utils import generate_worker_config, read_config
 from ramp_utils.testing import database_config_template
@@ -18,6 +20,7 @@ from ramp_utils.testing import ramp_config_template
 
 from .test_dispatcher import session_toy  # noqa
 
+from unittest import mock
 
 HERE = os.path.dirname(__file__)
 
@@ -31,6 +34,34 @@ logging.basicConfig(
 def add_empty_dir(dir_name):
     if not os.path.exists(dir_name):
         os.mkdir(dir_name)
+
+
+@mock.patch("boto3.session.Session")
+def test_too_many_instances(boto_session_cls):
+    ''' test launching more instances than limit on AWS enabled'''
+    # dummy mock session
+    # test that the following error is caught:
+    # botocore.exceptions.ClientError: An error occurred
+    # (MaxSpotInstanceCountExceeded) when calling the
+    # RequestSpotInstances operation: Max spot instance count exceeded
+    session = boto_session_cls.return_value
+    client = session.client.return_value
+    describe_images = client.describe_images
+    images = {"Images": [{"ImageId": 1}]}
+    describe_images.return_value = images
+
+    error = {
+        "ClientError": {
+            "Code": "Max spot instance count exceeded"
+        }
+    }
+    config = read_config(os.path.join(HERE, '_config.yml'))
+    config['worker']['use_spot_instance'] = True
+    request_spot_instances = client.request_spot_instances
+    error = botocore.exceptions.ClientError(error,
+                                            "MaxSpotInstanceCountExceeded")
+    request_spot_instances.side_effect = error
+    launch_ec2_instances(config['worker'])
 
 
 def test_aws_worker():


### PR DESCRIPTION
Add handling of errors thrown by AWS when creating a spot instance
+ tests


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
