### PR TITLE
Dispatcher: handle worker errors

### DIFF
--- a/ramp-engine/ramp_engine/dispatcher.py
+++ b/ramp-engine/ramp_engine/dispatcher.py
@@ -153,11 +153,15 @@ class Dispatcher:
             worker, (submission_id, submission_name) = \
                 self._awaiting_worker_queue.get()
             logger.info('Starting worker: {}'.format(worker))
-            worker.setup()
-            if worker.status == 'error':
-                set_submission_state(session, submission_id, 'checking_error')
-                continue
-            worker.launch_submission()
+
+            try:
+                worker.setup()
+                if worker.status != "error":
+                    worker.launch_submission()
+            except Exception as e:
+                logger.error('Worker finished with unhandled exception:'
+                             f' {e}')
+                worker.status = 'error'
             if worker.status == 'error':
                 set_submission_state(session, submission_id, 'checking_error')
                 continue

--- a/ramp-engine/ramp_engine/tests/test_dispatcher.py
+++ b/ramp-engine/ramp_engine/tests/test_dispatcher.py
@@ -2,7 +2,6 @@ import shutil
 import os
 
 import pytest
-from unittest import mock
 
 from ramp_utils import read_config
 from ramp_utils.testing import database_config_template
@@ -36,12 +35,6 @@ def session_toy(database_connection):
         shutil.rmtree(deployment_dir, ignore_errors=True)
         db, _ = setup_db(database_config['sqlalchemy'])
         Model.metadata.drop_all(db)
-
-
-@mock.patch.object(Dispatcher, 'launch_workers')
-def test_something(mock_method):
-    Dispatcher.launch_workers().returvalue = None
-    mock_method.assert_called_with()
 
 
 def test_error_handling_worker_setup_error(session_toy, caplog):

--- a/ramp-engine/ramp_engine/tests/test_dispatcher.py
+++ b/ramp-engine/ramp_engine/tests/test_dispatcher.py
@@ -44,7 +44,7 @@ def test_something(mock_method):
     mock_method.assert_called_with()
 
 
-def test_error_handling_on_aws_worker_setup_error(session_toy, caplog):
+def test_error_handling_worker_setup_error(session_toy, caplog):
     # make sure the error on the worker.setup is dealt with correctly
     # set mock worker
     class Worker_mock():

--- a/ramp-engine/ramp_engine/tests/test_dispatcher.py
+++ b/ramp-engine/ramp_engine/tests/test_dispatcher.py
@@ -43,12 +43,11 @@ def test_something(mock_method):
     Dispatcher.launch_workers().returvalue = None
     mock_method.assert_called_with()
 
-# ramp_database.tools.submission
-#@mock.patch("ramp_engine.dispatcher.set_submission_state", side_effect=None)
+
 def test_error_handling_on_aws_worker_setup_error(session_toy, caplog):
     # make sure the error on the worker.setup is dealt with correctly
-    # set mock AWSworker
-    class AWSWorker_mock():
+    # set mock worker
+    class Worker_mock():
         def __init__(self, *args, **kwargs):
             self.state = None
 
@@ -58,9 +57,9 @@ def test_error_handling_on_aws_worker_setup_error(session_toy, caplog):
     config = read_config(database_config_template())
     event_config = read_config(ramp_config_template())
 
-    worker = AWSWorker_mock()
+    worker = Worker_mock()
     dispatcher = Dispatcher(
-        config=config, event_config=event_config, worker=AWSWorker_mock,
+        config=config, event_config=event_config, worker=Worker_mock,
         n_workers=-1, hunger_policy='exit'
     )
 


### PR DESCRIPTION
The dispatcher gets some unhandled errors when running the worker and it breaks
this is to ensure that the dispatcher does not break

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
