### PR TITLE
Add timout to ssh

### DIFF
--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -940,17 +940,20 @@ def is_spot_terminated(config, instance_id):
     'instance-action' will be present."""
     cmd_timeout = 1
     n_retry = 5
-    #cmd = "curl http://169.254.169.254/latest/meta-data/instance-action" # -m cmd_timeout --retry n_retry
-    #try:
-    out = _run(config, instance_id, cmd, return_output=True)
-    # except subprocess.CalledProcessError:
-    #     logger.error('Unable to run curl: {e}')
-    #    terminated = False
-    #except Exception as e:
-    #    logger.error('Unhandled exception happend when checking if there'
-    #                 f' is an instance action: {e}')
-    #    terminated = False
-    out = out.decode('utf-8')
+    cmd = ("curl http://169.254.169.254/latest/meta-data/instance-action"
+           f" -m {cmd_timeout} --retry {n_retry}")
+
+    try:
+        out = _run(config, instance_id, cmd, return_output=True)
+        out = out.decode('utf-8')
+    except subprocess.CalledProcessError:
+        logger.error('Unable to run curl: {e}')
+        return False
+    except Exception as e:
+        logger.error('Unhandled exception happend when checking if there'
+                     f' is an instance action: {e}')
+        return False
+
     if out == 'none':
         terminated = False
     else:

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -911,8 +911,18 @@ def is_spot_terminated(config, instance_id):
     """Check if there is an 'instance-action' item present in instance
     metatdata. If a spot instance is marked to be terminated an
     'instance-action' will be present."""
-    cmd = "curl http://169.254.169.254/latest/meta-data/instance-action"
+    cmd_timeout = 1
+    n_retry = 5
+    #cmd = "curl http://169.254.169.254/latest/meta-data/instance-action" # -m cmd_timeout --retry n_retry
+    #try:
     out = _run(config, instance_id, cmd, return_output=True)
+    # except subprocess.CalledProcessError:
+    #     logger.error('Unable to run curl: {e}')
+    #    terminated = False
+    #except Exception as e:
+    #    logger.error('Unhandled exception happend when checking if there'
+    #                 f' is an instance action: {e}')
+    #    terminated = False
     out = out.decode('utf-8')
     if out == 'none':
         terminated = False

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -939,7 +939,7 @@ def is_spot_terminated(config, instance_id):
     metatdata. If a spot instance is marked to be terminated an
     'instance-action' will be present."""
     cmd_timeout = 1
-    n_retry = 5
+    n_retry = 9
     cmd = ("curl http://169.254.169.254/latest/meta-data/instance-action"
            f" -m {cmd_timeout} --retry {n_retry}")
 
@@ -950,8 +950,8 @@ def is_spot_terminated(config, instance_id):
         logger.error('Unable to run curl: {e}')
         return False
     except Exception as e:
-        logger.error('Unhandled exception happend when checking if there'
-                     f' is an instance action: {e}')
+        logger.error('Unhandled exception occurred when checking for'
+                     f' instance action: {e}')
         return False
 
     if out == 'none':

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -98,7 +98,7 @@ def test_creating_instances(boto_session_cls, caplog,
     assert (instance is None) == result_none
     assert log_msg in caplog.text
 
-'''
+
 def test_aws_worker():
     if not os.path.isfile(os.path.join(HERE, 'config.yml')):
         pytest.skip("Only for local tests for now")
@@ -159,4 +159,3 @@ def test_aws_dispatcher(session_toy):  # noqa
         session_toy, event_config['ramp']['event_name'], 'training_error'
     )
     assert len(submission) == 2
-'''

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -8,11 +8,12 @@ import botocore
 import logging
 import os
 import shutil
+import subprocess
 
 import pytest
 
 from ramp_database.tools.submission import get_submissions
-from ramp_engine.aws.api import launch_ec2_instances
+from ramp_engine.aws.api import is_spot_terminated, launch_ec2_instances
 from ramp_engine import Dispatcher, AWSWorker
 from ramp_utils import generate_worker_config, read_config
 from ramp_utils.testing import database_config_template
@@ -34,6 +35,15 @@ logging.basicConfig(
 def add_empty_dir(dir_name):
     if not os.path.exists(dir_name):
         os.mkdir(dir_name)
+
+
+@mock.patch('ramp_engine.aws.api._run')
+def test_is_spot_terminated_with_CalledProcessError(test_run, caplog):
+    test_run.side_effect = subprocess.CalledProcessError(28, 'test')
+    config = read_config(os.path.join(HERE, '_config.yml'))
+    instance_id = 0
+    is_spot_terminated(config, instance_id)
+    assert 'Unable to run curl' in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -88,7 +98,7 @@ def test_creating_instances(boto_session_cls, caplog,
     assert (instance is None) == result_none
     assert log_msg in caplog.text
 
-
+'''
 def test_aws_worker():
     if not os.path.isfile(os.path.join(HERE, 'config.yml')):
         pytest.skip("Only for local tests for now")
@@ -149,3 +159,4 @@ def test_aws_dispatcher(session_toy):  # noqa
         session_toy, event_config['ramp']['event_name'], 'training_error'
     )
     assert len(submission) == 2
+'''


### PR DESCRIPTION
Adds a timeout to curl and handles the exceptions in case there are any errors with subprocess output (before the connection just hanged sometimes stopping the work of the whole dispatcher).

The problem which remains and I don't know how to approach is that even if the connection is not established after (what is set now) 9 tries, with initial time 1sec doubled after each next try (ie max waiting time 8.51 min) the only thing we are able to return is either that the instance finished or not (ie True or False). If for any reason the instance is lost (shutting by hand, other scenarios (??) ) it will still try connecting to it the next time again.

This might be a problem for another PR though..
