### PR TITLE
BUG error in the name of the submission state

### DIFF
--- a/ramp-engine/ramp_engine/dispatcher.py
+++ b/ramp-engine/ramp_engine/dispatcher.py
@@ -275,7 +275,7 @@ class Dispatcher:
         submissions = get_submissions(session, even_name, state=None)
         for submission_id, _, _ in submissions:
             submission_state = get_submission_state(session, submission_id)
-            if submission_state in ('training', 'send_to_training'):
+            if submission_state in ('training', 'sent_to_training'):
                 set_submission_state(session, submission_id, 'new')
 
     def launch(self):


### PR DESCRIPTION
There is a mistake in the name of the submission ('send_to_training' instead of 'sent_to_training') so each time the dispatcher is restarted the submissions with the status 'sent_to_training' hang


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
