### PR TITLE
ENH gets latest image if more than one

### DIFF
--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -251,26 +251,28 @@ def launch_ec2_instances(config, nb=1):
 def _get_image_id(config, image_name):
     sess = _get_boto_session(config)
     client = sess.client('ec2')
+
+    # get all the images with the given imange_name in the name
     result = client.describe_images(Filters=[
         {
             'Name': 'name',
-            'Values': [
-                image_name
-            ]
+            'Values': [image_name+'*'
+                       ],
         }
     ])
+
     images = result['Images']
     if len(images) == 0:
         raise ValueError(
             'No image corresponding to the name "{}"'.format(image_name))
     elif len(images) > 1:
-        raise ValueError(
-            'Multiple images corresponding to the name "{}".'
-            ' Please fix that'.format(image_name))
+        # get only the newest image if there are more than one
+        image = sorted(images, key=lambda x: x['CreationDate'],
+                       reverse=True)[0]
     else:
         image = images[0]
-        image_id = image['ImageId']
-        return image_id
+    image_id = image['ImageId']
+    return image_id
 
 
 def terminate_ec2_instance(config, instance_id):
@@ -372,7 +374,16 @@ def upload_submission(config, instance_id, submission_name,
     submission_path = os.path.join(submissions_dir, submission_name)
     ramp_kit_folder = config[REMOTE_RAMP_KIT_FOLDER_FIELD]
     dest_folder = os.path.join(ramp_kit_folder, SUBMISSIONS_FOLDER)
-    return _upload(config, instance_id, submission_path, dest_folder)
+
+    # catch an error when uploading if they happen
+    try:
+        out = _upload(config, instance_id, submission_path, dest_folder)
+        return out
+    except subprocess.CalledProcessError as e:
+        logger.error(f'Unable to connect during log download: {e}')
+    except Exception as e:
+        logger.error(f'Unknown error occured during log download: {e}')
+    return 1
 
 
 def download_log(config, instance_id, submission_name, folder=None):
@@ -409,7 +420,19 @@ def download_log(config, instance_id, submission_name, folder=None):
         os.makedirs(os.path.dirname(dest_path))
     except OSError:
         pass
-    return _download(config, instance_id, source_path, dest_path)
+
+    # try connecting few times
+    n_tries = 3
+    for n_try in range(n_tries):
+        try:
+            out = _download(config, instance_id, source_path, dest_path)
+            return out
+        except Exception as e:
+            logger.error(f'Unknown error occured during log download: {e}')
+            if n_try == n_tries-1:
+                raise(e)
+            else:
+                logger.error('Trying to download the log once again')
 
 
 def _get_log_content(config, submission_name):
@@ -531,8 +554,18 @@ def download_predictions(config, instance_id, submission_name, folder=None):
         os.makedirs(os.path.dirname(dest_path))
     except OSError:
         pass
-    _download(config, instance_id, source_path, dest_path)
-    return dest_path
+    n_tries = 3
+    for n_try in range(n_tries):
+        try:
+            _download(config, instance_id, source_path, dest_path)
+            return dest_path
+        except Exception as e:
+            logger.error('Unknown error occured when downloading prediction'
+                         f' e: {str(e)}')
+            if n_try == n_tries-1:
+                raise(e)
+            else:
+                logger.error('Trying to download the prediction once again')
 
 
 def _get_remote_training_output_folder(config, instance_id, submission_name):

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -256,7 +256,7 @@ def _get_image_id(config, image_name):
     result = client.describe_images(Filters=[
         {
             'Name': 'name',
-            'Values': [image_name+'*'
+            'Values': [f'{image_name}*'
                        ],
         }
     ])
@@ -265,12 +265,10 @@ def _get_image_id(config, image_name):
     if len(images) == 0:
         raise ValueError(
             'No image corresponding to the name "{}"'.format(image_name))
-    elif len(images) > 1:
-        # get only the newest image if there are more than one
-        image = sorted(images, key=lambda x: x['CreationDate'],
-                       reverse=True)[0]
-    else:
-        image = images[0]
+
+    # get only the newest image if there are more than one
+    image = sorted(images, key=lambda x: x['CreationDate'],
+                   reverse=True)[0]
     image_id = image['ImageId']
     return image_id
 

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -374,16 +374,7 @@ def upload_submission(config, instance_id, submission_name,
     submission_path = os.path.join(submissions_dir, submission_name)
     ramp_kit_folder = config[REMOTE_RAMP_KIT_FOLDER_FIELD]
     dest_folder = os.path.join(ramp_kit_folder, SUBMISSIONS_FOLDER)
-
-    # catch an error when uploading if they happen
-    try:
-        out = _upload(config, instance_id, submission_path, dest_folder)
-        return out
-    except subprocess.CalledProcessError as e:
-        logger.error(f'Unable to connect during log download: {e}')
-    except Exception as e:
-        logger.error(f'Unknown error occured during log download: {e}')
-    return 1
+    return _upload(config, instance_id, submission_path, dest_folder)
 
 
 def download_log(config, instance_id, submission_name, folder=None):
@@ -420,19 +411,7 @@ def download_log(config, instance_id, submission_name, folder=None):
         os.makedirs(os.path.dirname(dest_path))
     except OSError:
         pass
-
-    # try connecting few times
-    n_tries = 3
-    for n_try in range(n_tries):
-        try:
-            out = _download(config, instance_id, source_path, dest_path)
-            return out
-        except Exception as e:
-            logger.error(f'Unknown error occured during log download: {e}')
-            if n_try == n_tries-1:
-                raise(e)
-            else:
-                logger.error('Trying to download the log once again')
+    return _download(config, instance_id, source_path, dest_path)
 
 
 def _get_log_content(config, submission_name):
@@ -554,18 +533,8 @@ def download_predictions(config, instance_id, submission_name, folder=None):
         os.makedirs(os.path.dirname(dest_path))
     except OSError:
         pass
-    n_tries = 3
-    for n_try in range(n_tries):
-        try:
-            _download(config, instance_id, source_path, dest_path)
-            return dest_path
-        except Exception as e:
-            logger.error('Unknown error occured when downloading prediction'
-                         f' e: {str(e)}')
-            if n_try == n_tries-1:
-                raise(e)
-            else:
-                logger.error('Trying to download the prediction once again')
+    _download(config, instance_id, source_path, dest_path)
+    return dest_path
 
 
 def _get_remote_training_output_folder(config, instance_id, submission_name):

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -269,8 +269,7 @@ def _get_image_id(config, image_name):
     # get only the newest image if there are more than one
     image = sorted(images, key=lambda x: x['CreationDate'],
                    reverse=True)[0]
-
-    return image_id['ImageId']
+    return image['ImageId']
 
 
 def terminate_ec2_instance(config, instance_id):

--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -252,7 +252,7 @@ def _get_image_id(config, image_name):
     sess = _get_boto_session(config)
     client = sess.client('ec2')
 
-    # get all the images with the given imange_name in the name
+    # get all the images with the given image_name in the name
     result = client.describe_images(Filters=[
         {
             'Name': 'name',
@@ -269,8 +269,8 @@ def _get_image_id(config, image_name):
     # get only the newest image if there are more than one
     image = sorted(images, key=lambda x: x['CreationDate'],
                    reverse=True)[0]
-    image_id = image['ImageId']
-    return image_id
+
+    return image_id['ImageId']
 
 
 def terminate_ec2_instance(config, instance_id):

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -191,7 +191,7 @@ def test_launch_ec2_instances(boto_session_cls, use_spot_instance):
     session = boto_session_cls.return_value
     client = session.client.return_value
     describe_images = client.describe_images
-    images = {"Images": [{"ImageId": 1}]}
+    images = {"Images": [{"ImageId": 1, "CreationDate": 123}]}
     describe_images.return_value = images
     config = read_config(os.path.join(HERE, '_aws_config.yml'))
 
@@ -218,7 +218,7 @@ def test_creating_instances(boto_session_cls, caplog,
     session = boto_session_cls.return_value
     client = session.client.return_value
     describe_images = client.describe_images
-    images = {"Images": [{"ImageId": 1}]}
+    images = {"Images": [{"ImageId": 1, "CreationDate": 123}]}
     describe_images.return_value = images
 
     error = {


### PR DESCRIPTION
**use case**: when pipeline is used each next version of the image will have the name image_name_{date_time_of_creation}

this PR enables a worker to find all the images which include the name image_name in their name and to select the newest one.

This only works if the image_name is given in the config file. If the id of the image will be given the worker will always use the same image with that ID.