### PR TITLE
Retry not wait when connecting to the instance on submiting solution

### DIFF
--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -57,7 +57,7 @@ MEMORY_PROFILING_FIELD = 'memory_profiling'
 
 # how long to wait for connections
 WAIT_MINUTES = 2
-MAX_TRIES_TO_CONNECT = 5
+MAX_TRIES_TO_CONNECT = 1
 
 HOOKS_SECTION = 'hooks'
 HOOK_START_TRAINING = 'start_training'
@@ -185,11 +185,11 @@ def launch_ec2_instances(config, nb=1):
                     time.sleep(wait_minutes*60)
                 else:
                     logger.error(f'Not enough instances available: {e}')
-                    return None,
+                    return None, 'retry'
             except Exception as e:
                 # unknown error
                 logger.error(f'AWS worker error: {e}')
-                return None,
+                return None, e
         # Wait until request fulfilled
         waiter = client.get_waiter('spot_instance_request_fulfilled')
         request_id = \
@@ -242,10 +242,10 @@ def launch_ec2_instances(config, nb=1):
         waiter = client.get_waiter('instance_status_ok')
         try:
             waiter.wait(InstanceIds=instance_ids)
-        except botocore.exceptions.WaiterError:
-            return None,
+        except botocore.exceptions.WaiterError as e:
+            return None, e
 
-    return instances
+    return instances, 0
 
 
 def _get_image_id(config, image_name):

--- a/ramp-engine/ramp_engine/aws/worker.py
+++ b/ramp-engine/ramp_engine/aws/worker.py
@@ -64,9 +64,9 @@ class AWSWorker(BaseWorker):
 
         if not _instances:
             if status == 'retry':
-                # there was a timeout error, put back in the queue and try
-                # again
-                logger.worning("Unable to launch instance for submission "
+                # there was a timeout error, put this submission back in the
+                # queue and try again later
+                logger.warning("Unable to launch instance for submission "
                                f"{self.submission}. Adding it back to the "
                                "queue and will try again later")
                 self.status = 'retry'
@@ -78,7 +78,7 @@ class AWSWorker(BaseWorker):
         else:
             logger.info("Instance launched for submission '{}'".format(
                         self.submission))
-            self.instances, = _instances
+            self.instance, = _instances
 
         for _ in range(5):
             # try uploading the submission a few times, as this regularly fails

--- a/ramp-engine/ramp_engine/tests/test_aws.py
+++ b/ramp-engine/ramp_engine/tests/test_aws.py
@@ -39,17 +39,13 @@ def add_empty_dir(dir_name):
         os.mkdir(dir_name)
 
 
-# @mock.patch('ramp_engine.aws.api._rsync')
 @mock.patch('ramp_engine.aws.api.launch_ec2_instances')
 def test_launch_ec2_instances_put_back_into_queue(test_launch_ec2_instances,
-                                                  # test_rsync
                                                   caplog):
     ''' checks if the retry status and the correct log is added if the
         api returns None instances and status retry '''
 
     test_launch_ec2_instances.return_value = None, 'retry'
-    # mock the called proecess error
-    # test_rsync.side_effect = subprocess.CalledProcessError(255, 'test')
 
     # setup the AWS worker
     event_config = read_config(os.path.join(HERE, '_aws_config.yml'))['worker']
@@ -63,15 +59,10 @@ def test_launch_ec2_instances_put_back_into_queue(test_launch_ec2_instances,
     assert 'Adding it back to the queue and will try again' in caplog.text
 
 
-@mock.patch('ramp_engine.aws.api.launch_ec2_instances')
-def test_launch_ec2_instances_error():
-    # test_launch_ec2_instances.return_value = None, unknown_error
-    pass
-
-
 @mock.patch('ramp_engine.aws.api._rsync')
 @mock.patch('ramp_engine.aws.api.launch_ec2_instances')
-def test_aws_worker_upload_error(test_launch_ec2_instances, test_rsync):
+def test_aws_worker_upload_error(test_launch_ec2_instances, test_rsync,
+                                 caplog):
     # mock dummy AWS instance
     class DummyInstance:
         id = 1
@@ -88,6 +79,8 @@ def test_aws_worker_upload_error(test_launch_ec2_instances, test_rsync):
 
     # CalledProcessError is thrown inside
     worker.setup()
+    assert worker.status == 'error'
+    assert 'Unable to connect during log download' in caplog.text
 
 
 @mock.patch('ramp_engine.aws.api._rsync')


### PR DESCRIPTION
Sometimes the worker cannot connect to the instance because there are not enough instances are available. This can happen for multiple of reasons one of them being that the instance which was set to terminate do not yet is available for the use.
For that reason we previously added a possibility to wait and try again few times before giving an error. 

This was not very efficient because it forced the whole dispatcher to wait this time and not allowing it to collect the results from other workers and possibly free an instance -> which would solve the problem of not having enough instances if the cause was different from the above.

This PR shortens the waiting time and if the instances are still not available it puts the worker back into the queue to try later. 