### PR TITLE
DOC use private instead of public data

### DIFF
--- a/doc/workers.rst
+++ b/doc/workers.rst
@@ -142,7 +142,7 @@ need to install git.
         ~ $ conda env update --name base --file $environment
         ~ $ conda list
 
-  - Get the data and copy public data to ``ramp-kits/<project>/data/``.
+  - Get the data and copy private data to ``ramp-kits/<project>/data/``.
     Note: depending on how ``prepare_data.py`` structures the data files,
     the last command may differ::
 
@@ -152,7 +152,7 @@ need to install git.
         ~ $ git clone $data_url $data_dir
         ~ $ cd $data_dir
         ~ $ python prepare_data.py
-        ~ $ cp data/public/* $kit_dir/data/
+        ~ $ cp data/private/* $kit_dir/data/
 
   - Test the kit::
 


### PR DESCRIPTION
Corrects a mistake in the docs suggesting using public instead of private dataset on the AWS instances. 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/paris-saclay-cds/ramp-board/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
