### PR TITLE
set timeout error as training error

### DIFF
--- a/ramp-engine/ramp_engine/dispatcher.py
+++ b/ramp-engine/ramp_engine/dispatcher.py
@@ -237,7 +237,7 @@ class Dispatcher:
                         self._logger.info(
                             f'Worker {worker} killed due to timeout.'
                         )
-                        submission_status = 'checking_error'
+                        submission_status = 'training_error'
                     elif returncode == 2:
                         # Error occurred when downloading the logs
                         submission_status = 'checking_error'


### PR DESCRIPTION
Previously I set the timeout error to `checking_error`. This should not be the case. Conda workers considers timeout as training error and AWS worker does not have the timeout error implemented at all. (hence #497)

Weirdly tests which should have been failing on Ci passed on previous PR (#495) and failed only for the release PR (https://github.com/paris-saclay-cds/ramp-board/tree/0.7.X).

Once this is corrected, and if green another bug release will be made