### PR TITLE
ENH AWS remove availibity zone group from the setting up instance

### DIFF
--- a/ramp-engine/ramp_engine/aws/api.py
+++ b/ramp-engine/ramp_engine/aws/api.py
@@ -163,7 +163,6 @@ def launch_ec2_instances(config, nb=1):
         while not(response) and (n_try < max_tries_to_connect):
             try:
                 response = client.request_spot_instances(
-                    AvailabilityZoneGroup=config[REGION_NAME_FIELD],
                     InstanceCount=nb,
                     LaunchSpecification={
                         'SecurityGroups': [security_group],


### PR DESCRIPTION
by setting availability zone group we are limiting our possible resources, therefore it is better not to set it.