### PR TITLE
MAINT Add missing pip dependency in ci_tools/environment_iris_kit.yml

### DIFF
--- a/ci_tools/environment_iris_kit.yml
+++ b/ci_tools/environment_iris_kit.yml
@@ -5,5 +5,6 @@ dependencies:
   - numpy
   - scikit-learn
   - pandas
+  - pip
   - pip:
     - ramp-workflow


### PR DESCRIPTION
I have recently seen some CI failures in https://github.com/paris-saclay-cds/ramp-board/pull/476 which should be unrelated to that PR, so opening a separate PR to investigate.