### PR TITLE
CI Test dev version of ramp-workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       ramp_workflow_url:
-        description: 'ramp-workflow repo URL'
+        description: 'pip installable ramp-workflow repo URL'
         required: true
-        default: 'https://github.com/paris-saclay-cds/ramp-workflow.git'
+        default: 'https://github.com/paris-saclay-cds/ramp-workflow/archive/refs/heads/master.zip'
 
 
 jobs:
@@ -65,7 +65,7 @@ jobs:
               python -m pip install "dask[distributed]==2021.4.0"
           fi
           if [ "${{ matrix.ramp_workflow_version }}" == "master" ]; then
-             pip install https://github.com/paris-saclay-cds/ramp-workflow.git
+             pip install https://github.com/paris-saclay-cds/ramp-workflow/archive/refs/heads/master.zip
           fi
           if [ "${{ github.event.inputs.ramp_workflow_url }}" != "" ]; then
              pip install "${{ github.event.inputs.ramp_workflow_url }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           source activate testenv
           if [ "$PYTHON_VERSION" == "3.8" ]; then
-              python -m pip install "dask==2021.4.1 distributed==2021.4.1"
+              python -m pip install "dask==2021.4.1" "distributed==2021.4.1"
           fi
           if [ "${{ matrix.ramp_workflow_version }}" == "master" ]; then
              pip install https://github.com/paris-saclay-cds/ramp-workflow/archive/refs/heads/master.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        python: [3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8, 3.9]
         include:
           - os: ubuntu-18.04
             python: 3.8
@@ -62,10 +62,10 @@ jobs:
           if [ "$PYTHON_VERSION" == "3.8" ]; then
               python -m pip install "dask[distributed]==2021.4.0"
           fi
-          if [ "${{ matrix.ramp_workflow_version }}" == "master" ]
+          if [ "${{ matrix.ramp_workflow_version }}" == "master" ]; then
              pip install https://github.com/paris-saclay-cds/ramp-workflow.git
           fi
-          if [ "${{ github.event.inputs.ramp_workflow_url }}" != "" ]
+          if [ "${{ github.event.inputs.ramp_workflow_url }}" != "" ]; then
              pip install "${{ github.event.inputs.ramp_workflow_url }}"
           fi
           make inplace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: main
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ramp_workflow_url:
+        description: 'ramp-workflow repo URL'
+        required: true
+        default: 'https://github.com/paris-saclay-cds/ramp-workflow.git'
 
 
 jobs:
@@ -11,6 +19,11 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         python: [3.6, 3.7, 3.8]
+        include:
+          - os: ubuntu-18.04
+            python: 3.8
+            ramp-workflow-version: master
+
 
     services:
       postgres:
@@ -48,6 +61,12 @@ jobs:
           source activate testenv
           if [ "$PYTHON_VERSION" == "3.8" ]; then
               python -m pip install "dask[distributed]==2021.4.0"
+          fi
+          if [ "${{ matrix.ramp_workflow_version }}" == "master" ]
+             pip install https://github.com/paris-saclay-cds/ramp-workflow.git
+          fi
+          if [ "${{ github.event.inputs.ramp_workflow_url }}" != "" ]
+             pip install "${{ github.event.inputs.ramp_workflow_url }}"
           fi
           make inplace
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           source activate testenv
           if [ "$PYTHON_VERSION" == "3.8" ]; then
-              python -m pip install "dask[distributed]==2021.4.0"
+              python -m pip install "dask==2021.4.1 distributed==2021.4.1"
           fi
           if [ "${{ matrix.ramp_workflow_version }}" == "master" ]; then
              pip install https://github.com/paris-saclay-cds/ramp-workflow/archive/refs/heads/master.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,9 @@ jobs:
         include:
           - os: ubuntu-18.04
             python: 3.8
-            ramp-workflow-version: master
+            # the following has no effect with manual trigger
+            # where the ramp-workflow is specified anyway
+            ramp_workflow_version: master
 
 
     services:


### PR DESCRIPTION
This adds a CI job to test the master version of ramp-worflow in CI.

There is also a manual trigger for CI that allow to enter any Github repo/branch, which would allow to run this test suite on individual PRs of ramp-workflow