### PR TITLE
ENH UI to delete account

### DIFF
--- a/ramp-frontend/ramp_frontend/templates/update_profile.html
+++ b/ramp-frontend/ramp_frontend/templates/update_profile.html
@@ -132,14 +132,38 @@
         <input type="submit" value="Update" class="ui submit button">
     </div>
     </form>
-  </div>
+   </div>
+   <div class="card">
+    <div class="card-header">
+      <div class="card-title">
+	<div class="title">Privacy</div>
+      </div>
+    </div>
+    <div class="card-body">
+    <input type="submit" value="Delete Account" class="ui submit button", id="delete-account-btn">
+   </div>
+   </div>
 </div>
 </div>
 {% endblock %}
 {% block scripts %}
 <script>
   $(function () {
-    $('#formerror').modal('toggle')
+    $('#formerror').modal('toggle');
+
+    $('#delete-account-btn').click(() => {
+      if (confirm(`
+	     WARNING: You are about to delete your RAMP account.
+	     This action is not reversible.
+	     Note that all your personal information will be removed, however
+	     your submissions will remain on the RAMP platform.
+
+	     Are you sure?
+        `) === true) {
+	window.location.href = '/delete_profile';
+     }
+    });
   });
+
 </script>
 {% endblock %}


### PR DESCRIPTION
This adds a UI so that users can delete their account.

Closes https://github.com/paris-saclay-cds/ramp-board/issues/511 and helps for the GDPR compliance https://github.com/paris-saclay-cds/ramp-board/issues/440

Under "Update profile" there is now a "Delete account" button,

![image](https://user-images.githubusercontent.com/630936/118404246-657ab680-b672-11eb-9d76-32c095773696.png)

Which when clicked triggers a confirmation form,
![image](https://user-images.githubusercontent.com/630936/118404298-abd01580-b672-11eb-97d5-271eaf975e96.png)

And after clicking OK all personal data will be removed. The existing user entry will be re-initialized to default values (i.e. empty fields) except for the following field,
 - `firstname`: "deleted"
 - `lastname`: "deleted"
 - `email`: "{user.id}@deleted.com"
 - `hashed_password`: randomly re-generated, and not the output of the hash function so no user input will ever match.

The 1 person team name will also be renamed to "deleted_{user.id}", however leaderboard will not be re-computed so the previous name would still be shown there.

Submissions will however not be removed. This similar to what happens when a Github account is removed (i.e. contributed code is not removed) and assumes that there are Terms of Use that mention that code essentially donated to the RAMP platform. Anyway removing all submissions for a users is technically more complex (need to re-compute leaderboards etc). Also for audit purposes it's still useful to have some records that the user existed.

Note that `access_level` remains unchanged, which makes it a bit less natural to filter deleted accounts. This is because, 
 - currently this works without a DB migration, and if we add `deleted` to the [`access_level` Enum](https://github.com/paris-saclay-cds/ramp-board/blob/675833488eb8c7f92f98931e7726d4483dface18/ramp-database/ramp_database/model/user.py#L131) it will require a migration, and besides this particular migration is not supported by alembic https://github.com/sqlalchemy/alembic/issues/278 requiring manual workarounds. 
 - also having that extra information about the account state can be useful.