### PR TITLE
TST Fix test_contributivity

### DIFF
--- a/ramp-database/ramp_database/tools/tests/test_submission.py
+++ b/ramp-database/ramp_database/tools/tests/test_submission.py
@@ -478,7 +478,8 @@ def test_compute_contributivity(session_scope_module):
     ramp_submission_dir = ramp_config['ramp_submissions_dir']
     ramp_predictions_dir = ramp_config['ramp_predictions_dir']
 
-    submission_id = 9
+    submission = get_submission_by_name(session_scope_module, 'iris_test',
+                                        'test_user', 'starting_kit')
 
     # for testing blending, we need to train a submission
     # ouputting predictions into the submission directory
@@ -486,12 +487,12 @@ def test_compute_contributivity(session_scope_module):
         ramp_kit_dir=ramp_kit_dir,
         ramp_data_dir=ramp_data_dir,
         ramp_submission_dir=ramp_submission_dir,
-        submission='submission_00000000{}'.format(submission_id),
+        submission=submission.basename,
         save_output=True)
 
     # Mark the submission as scored in the DB
     sub = (session.query(Submission)
-                  .filter(Submission.id == submission_id)
+                  .filter(Submission.id == submission.id)
                   .first())
     sub.set_state('scored')
     session.commit()


### PR DESCRIPTION
Closes https://github.com/paris-saclay-cds/ramp-board/issues/527

This fixes the CI issue with test_contributivity.

The issue is that that test used a hardcoded submission id, however it looks like tests execution order is not fully deterministic and so occasionally that submission id ended up being the [error iris submission](https://github.com/ramp-kits/iris/tree/master/submissions/error) resulting in an error.

Will merge when CI passes since it's a blocker for other PRs. Will look into docs CI in another PR.