### PR TITLE
MAINT Drop Python 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9]
         include:
           - os: ubuntu-18.04
             python: 3.8

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Installation
     cd ramp-board
     ```
 
-2. Install Python dependencies using `conda` or `pip`
+2. Install Python 3.7+ and dependencies using `conda` or `pip`:
 
     - with `conda`
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,6 +7,8 @@ Install
 Install from PyPI
 =================
 
+Ramp-board requires Python 3.7+.
+
 The RAMP bundle is available in PyPI and can be installed via `pip`::
 
     pip install ramp-database ramp-engine ramp-frontend ramp-utils

--- a/ramp-database/setup.py
+++ b/ramp-database/setup.py
@@ -61,6 +61,7 @@ setup(
     package_data=PACKAGE_DATA,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
+    python_requires=">=3.7",
     entry_points={
         'console_scripts': ['ramp-database = ramp_database.cli:start']
     }

--- a/ramp-engine/setup.py
+++ b/ramp-engine/setup.py
@@ -60,6 +60,7 @@ setup(
     package_data=PACKAGE_DATA,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
+    python_requires=">=3.7",
     entry_points={
         'console_scripts': ['ramp-launch = ramp_engine.cli:start']
     }

--- a/ramp-frontend/setup.py
+++ b/ramp-frontend/setup.py
@@ -72,6 +72,7 @@ setup(
     package_data=PACKAGE_DATA,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
+    python_requires=">=3.7",
     entry_points={
         'console_scripts': ['ramp-frontend = ramp_frontend.cli:start']
     }

--- a/ramp-utils/setup.py
+++ b/ramp-utils/setup.py
@@ -63,6 +63,7 @@ setup(
     package_data=PACKAGE_DATA,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
+    python_requires=">=3.7",
     entry_points={
         'console_scripts': [
             'ramp = ramp_utils.ramp_cli:main',


### PR DESCRIPTION
ramp-board is an application so there are less reasons to support 4 versions of Python in CI. ramp.studio uses python 3.7.