### PR TITLE
Add User.update_timestamp field + order users to approve

### DIFF
--- a/doc/whats_new/v0.9.rst
+++ b/doc/whats_new/v0.9.rst
@@ -10,7 +10,7 @@ Changelog
 `ramp-database`
 ...............
 
-- Add `User.update_timestamp` database field :pr:`536`
+- Add `User.update_timestamp` database field :pr:`537`
 
 
 `ramp-engine`
@@ -20,7 +20,7 @@ Changelog
 `ramp-frontend`
 ...............
 
-- The list of users to approve are sorted by newest first :pr:`536`
+- The list of users to approve are sorted by newest first :pr:`537`
 
 
 `ramp-utils`

--- a/doc/whats_new/v0.9.rst
+++ b/doc/whats_new/v0.9.rst
@@ -1,6 +1,6 @@
 .. _changes_0_9:
 
-Version 0.8 (ongoing)
+Version 0.9 (ongoing)
 =====================
 
 Changelog
@@ -10,6 +10,8 @@ Changelog
 `ramp-database`
 ...............
 
+- Add `User.update_timestamp` database field :pr:`536`
+
 
 `ramp-engine`
 .............
@@ -17,6 +19,8 @@ Changelog
 
 `ramp-frontend`
 ...............
+
+- The list of users to approve are sorted by newest first :pr:`536`
 
 
 `ramp-utils`

--- a/ramp-database/ramp_database/model/user.py
+++ b/ramp-database/ramp_database/model/user.py
@@ -8,6 +8,7 @@ from sqlalchemy import Integer
 from sqlalchemy import Boolean
 from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
+from sqlalchemy import sql
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 
@@ -132,6 +133,8 @@ class User(Model):
         default='asked'
     )
     signup_timestamp = Column(DateTime, nullable=False)
+    update_timestamp = Column(DateTime, onupdate=sql.func.now(),
+                              server_default=sql.func.now())
 
     # Flask-Login fields
     is_authenticated = Column(Boolean, default=False)

--- a/ramp-frontend/ramp_frontend/views/admin.py
+++ b/ramp-frontend/ramp_frontend/views/admin.py
@@ -54,7 +54,12 @@ def approve_users():
         )
     if request.method == 'GET':
         # TODO: replace by some get_functions
-        asked_users = User.query.filter_by(access_level='asked').all()
+        asked_users = (
+            User.query
+            .filter_by(access_level='asked')
+            .order_by(User.id.desc())
+            .all()
+        )
         asked_sign_up = EventTeam.query.filter_by(approved=False).all()
         return render_template('approve.html',
                                asked_users=asked_users,


### PR DESCRIPTION
This makes two changes.
 - adds a `User.update_timestamp` field that is updated for each change of the User table. This is useful mostly for audits. For instance if an admin approved a user by mistake (which happened in the past), it's very difficult to determine which user was changed without this field. This requires a DB migration, but I can do it for ramp.studio

 - Orders the list of users to approve in the admin page by newest at the top.