### PR TITLE
Add teams 2/3: Add functions to manage teams

### DIFF
--- a/ramp-database/ramp_database/model/event.py
+++ b/ramp-database/ramp_database/model/event.py
@@ -210,8 +210,11 @@ class Event(Model):
         each team."""
         self.n_submissions = 0
         for event_team in self.event_teams:
-            # substract one for starting kit
-            self.n_submissions += len(event_team.submissions) - 1
+            if event_team.team.is_individual:
+                # substract one for starting kit
+                self.n_submissions += len(event_team.submissions) - 1
+            else:
+                self.n_submissions += len(event_team.submissions)
 
     @property
     def Predictions(self):
@@ -567,3 +570,8 @@ class EventTeam(Model):
 
     def __repr__(self):
         return "{}/{}".format(self.event, self.team)
+
+    @property
+    def is_locked(self):
+        """Check if event team is locked"""
+        return len(self.submissions) > 1

--- a/ramp-database/ramp_database/testing.py
+++ b/ramp-database/ramp_database/testing.py
@@ -158,7 +158,7 @@ def setup_ramp_kit_ramp_data(
                 'it, you need to set "force=True".'
             )
         shutil.rmtree(problem_kit_path, ignore_errors=True)
-    ramp_kit_url = "https://github.com/ramp-kits/{}.git".format(problem_name)
+    ramp_kit_url = f"https://github.com/ramp-kits/{problem_name}.git"
     kwargs = {}
     if depth is not None:
         kwargs["depth"] = depth

--- a/ramp-database/ramp_database/tools/submission.py
+++ b/ramp-database/ramp_database/tools/submission.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os
 import shutil
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -36,7 +37,14 @@ logger = logging.getLogger("RAMP-DATABASE")
 
 # Add functions: add information to the database
 # TODO: move the queries in "_query"
-def add_submission(session, event_name, team_name, submission_name, submission_path):
+def add_submission(
+    session,
+    event_name,
+    team_name,
+    submission_name,
+    submission_path,
+    user_name: Optional[str] = None,
+):
     """Create a submission in the database and returns an handle.
 
     Parameters
@@ -53,6 +61,9 @@ def add_submission(session, event_name, team_name, submission_name, submission_p
         The path of the files associated to the current submission. It will
         corresponds to the key `ramp_kit_subissions_dir` of the dictionary
         created with :func:`ramp_utils.generate_ramp_config`.
+    user_name: str, default=None
+        Optional user name to make the submission as for non
+        individual teams. This is only used for audits.
 
     Returns
     -------
@@ -101,7 +112,10 @@ def add_submission(session, event_name, team_name, submission_name, submission_p
                 )
 
         submission = Submission(
-            name=submission_name, event_team=event_team, session=session
+            name=submission_name,
+            event_team=event_team,
+            session=session,
+            user_name=user_name,
         )
         for cv_fold in event.cv_folds:
             submission_on_cv_fold = SubmissionOnCVFold(

--- a/ramp-database/ramp_database/tools/team.py
+++ b/ramp-database/ramp_database/tools/team.py
@@ -1,15 +1,91 @@
 import logging
 import os
+from typing import List, Optional
 
-from ..model import EventTeam
+from ..model import EventTeam, Team, UserTeam, Event, User
 
 from .submission import add_submission
 
 from ._query import select_event_by_name
 from ._query import select_event_team_by_name
+from ._query import select_event_team_by_user_name
 from ._query import select_team_by_name
+from ._query import select_user_by_name
 
 logger = logging.getLogger("RAMP-DATABASE")
+
+
+def add_team(
+    session, team_name: str, user_name: str, is_individual: bool = True
+) -> Team:
+    """Create a new team
+
+    Note that the behavior will change depending on whether it's
+    an individual team (i.e. team_name == user_name) or not.
+
+    NOTE: before creating a non individual team, you need to leave
+    all current teams for the current event with :func:`leave_all_teams`.
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.Session`
+        The session to directly perform the operation on the database.
+    event_name : str
+        The RAMP event name.
+    user_name : str
+        The name of admin user
+    is_individual : bool
+        This is an individual team
+
+    Returns
+    -------
+    team : :class:`ramp_database.model.Team`
+        The created team.
+    """
+    user = select_user_by_name(session, user_name)
+    team = Team(name=team_name, admin=user, is_individual=is_individual)
+    logger.info(f"Created {team} by {user}")
+    session.add(team)
+    session.commit()
+
+    if not is_individual:
+        user_team = UserTeam(team_id=team.id, user_id=user.id, status="accepted")
+        session.add(user_team)
+
+    session.commit()
+
+    return team
+
+
+def leave_all_teams(session, event_name: str, user_name: str):
+    """Leave all teams for a given user and event (except for invididual teams)
+
+    Note that the behavior will change depending on whether it's
+    an individual team (i.e. team_name == user_name) or not.
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.Session`
+        The session to directly perform the operation on the database.
+    event_name : str
+        The RAMP event name.
+    user_name : str
+        The name of admin user
+    """
+    (
+        session.query(UserTeam)
+        .filter(
+            UserTeam.status == "accepted",
+            UserTeam.user_id == User.id,
+            User.name == user_name,
+            UserTeam.team_id == Team.id,
+            EventTeam.team_id == Team.id,
+            EventTeam.event_id == Event.id,
+            Event.name == event_name,
+        )
+        .delete(synchronize_session="fetch")
+    )
+    session.commit()
 
 
 def ask_sign_up_team(session, event_name, team_name):
@@ -47,7 +123,7 @@ def ask_sign_up_team(session, event_name, team_name):
     return event, team, event_team
 
 
-def sign_up_team(session, event_name, team_name):
+def sign_up_team(session, event_name, team_name, user_name: Optional[str] = None):
     """Register a team to a RAMP event and submit the starting kit.
 
     Parameters
@@ -58,6 +134,9 @@ def sign_up_team(session, event_name, team_name):
         The RAMP event name.
     team_name : str
         The name of the team.
+    user_name : str, default=None
+        Optional user_name to make the submission as for non individual teams.
+        This is only used for audits.
     """
     event, team, event_team = ask_sign_up_team(session, event_name, team_name)
     # setup the sandbox
@@ -71,6 +150,7 @@ def sign_up_team(session, event_name, team_name):
         team_name,
         submission_name,
         path_sandbox_submission,
+        user_name=user_name,
     )
     logger.info("Copying the submission files into the deployment folder")
     logger.info("Adding {}".format(submission))
@@ -95,7 +175,7 @@ def delete_event_team(session, event_name, team_name):
     session.commit()
 
 
-def get_event_team_by_name(session, event_name, user_name):
+def get_event_team_by_name(session, event_name, team_name):
     """Get the event/team given an event and a user.
 
     Parameters
@@ -112,4 +192,168 @@ def get_event_team_by_name(session, event_name, user_name):
     event_team : :class:`ramp_database.model.EventTeam`
         The event/team instance queried.
     """
-    return select_event_team_by_name(session, event_name, user_name)
+    return select_event_team_by_name(session, event_name, team_name)
+
+
+def get_event_team_by_user_name(session, event_name, user_name):
+    """Get the event/team given an event and a user.
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.Session`
+        The session to directly perform the operation on the database.
+    event_name : str
+        The RAMP event name.
+    team_name : str
+        The name of the team.
+
+    Returns
+    -------
+    event_team : :class:`ramp_database.model.EventTeam`
+        The event/team instance queried.
+    """
+    return select_event_team_by_user_name(session, event_name, user_name)
+
+
+def add_team_member(
+    session, team_name: str, user_name: str, status="asked"
+) -> List[str]:
+    """Add a member to the team
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.Session`
+        The session to directly perform the operation on the database.
+    team_name : str
+        The name of the team.
+    user_name : str
+        The name of the user.
+    status: str
+        Membership status.
+
+    Returns
+    -------
+    errors :
+        A list with errors. An empty list if the addition succeded.
+    """
+    team = select_team_by_name(session, team_name)
+    user = select_user_by_name(session, user_name)
+    individual_team = select_team_by_name(session, user_name)
+    if team.is_individual:
+        return [f"Cannot add members to an individual Team({team_name})"]
+
+    event_team = session.query(EventTeam).filter_by(team_id=team.id).one_or_none()
+    event = None
+    if event_team is not None:
+        # Team is signed up to an event. Make sure the user is also signed up
+        # to the same event, otherwise they cannot be added to the team
+        event = event_team.event
+        if (
+            session.query(EventTeam)
+            .filter_by(event_id=event_team.event.id, team_id=individual_team.id)
+            .count()
+            == 0
+        ):
+            return [
+                (
+                    f"{team} is signed up to {event} however {user} isn't signed up "
+                    f"to this event. Therefore cannot invite them."
+                )
+            ]
+
+    if session.query(UserTeam).filter_by(user=user, team=team).count():
+        logging.info(f"add_team_member: {user} is already in {team}. Skipping")
+
+    logging.info(f"Adding {user} to {team} both belonging to {event}")
+    user_team = UserTeam(user_id=user.id, team_id=team.id, status=status)
+    session.add(user_team)
+    session.commit()
+    return []
+
+
+def get_team_members(session, team_name: str, status="accepted") -> List[Team]:
+    """Get team members
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.Session`
+        The session to directly perform the operation on the database.
+    team_name : str
+        The name of the team.
+    status: str
+        With a given status
+
+    Returns
+    -------
+    teams:
+       a list of teams.
+    """
+    if status not in ["asked", "accepted"]:
+        raise ValueError(f"status={status} must be one of ['asked', 'accepted']")
+    team = session.query(Team).filter_by(name=team_name).one_or_none()
+    if team is None:
+        return []
+    members = (
+        session.query(User)
+        .filter(
+            User.id == UserTeam.user_id,
+            UserTeam.team_id == team.id,
+            UserTeam.status == status,
+        )
+        .distinct()
+        .all()
+    )
+    return list(set(members))
+
+
+def respond_team_invite(
+    session,
+    user_name: str,
+    team_name: str,
+    action: str,
+    event_name: Optional[str] = None,
+):
+    """Respond to a team invite
+
+    Either by accepting or declining. When event_name is not None, the user
+    will leave all other non individual teams.
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.Session`
+        The session to directly perform the operation on the database.
+    team_name : str
+        The name of the team.
+    action: str
+        Either accept or decline the invite. One of ['accept', 'decline'].
+    event_name : str
+        The RAMP event name. Only used to leave all current teams for the event.
+        If None, no teams will be left.
+    """
+    user_team = (
+        session.query(UserTeam)
+        .filter(
+            User.id == UserTeam.user_id,
+            Team.id == UserTeam.team_id,
+            User.name == user_name,
+            Team.name == team_name,
+            UserTeam.status == "asked",
+        )
+        .one_or_none()
+    )
+    if user_team is None:
+        raise ValueError(
+            f"Could not find invites for User({user_name}) " f"to Team({team_name})"
+        )
+    if action == "accept":
+        if event_name is not None:
+            leave_all_teams(session, event_name, user_name)
+        user_team.status = "accepted"
+        session.add(user_team)
+    elif action == "decline":
+        session.delete(user_team)
+    else:
+        raise ValueError(
+            f"unknown action={action} expected one of " f"['accept', 'decline']"
+        )
+    session.commit()

--- a/ramp-database/ramp_database/tools/tests/test_query.py
+++ b/ramp-database/ramp_database/tools/tests/test_query.py
@@ -4,6 +4,7 @@ import shutil
 from ramp_database.model import Model
 from ramp_database.model import User
 from ramp_database.model import Submission
+from ramp_database.model import EventTeam
 from ramp_utils import read_config
 from ramp_utils.testing import database_config_template
 from ramp_utils.testing import ramp_config_template
@@ -15,6 +16,8 @@ from ramp_database.tools._query import (
     select_submission_by_name,
     select_submission_by_id,
     select_user_by_name,
+    select_event_team_by_user_name,
+    select_team_invites_by_user_name,
 )
 
 
@@ -82,3 +85,20 @@ def test_select_submissions_by_id(session_scope_module):
 
     res = select_submission_by_id(session, 99999)
     assert res is None
+
+
+def test_select_event_team_by_user_name(session_scope_module):
+    session = session_scope_module
+
+    res = select_event_team_by_user_name(session, "iris_test", "invalid_user")
+    assert res is None
+
+    res = select_event_team_by_user_name(session, "iris_test", "test_user_2")
+    assert isinstance(res, EventTeam)
+
+
+def test_select_team_invites_by_user_name(session_scope_module):
+    session = session_scope_module
+
+    res = select_team_invites_by_user_name(session, "iris_test", "test_user_2")
+    assert res == []

--- a/ramp-database/ramp_database/tools/tests/test_team.py
+++ b/ramp-database/ramp_database/tools/tests/test_team.py
@@ -14,6 +14,8 @@ from ramp_database.model import Model
 from ramp_database.model import Submission
 from ramp_database.model import SubmissionOnCVFold
 from ramp_database.model import User
+from ramp_database.model import Team
+from ramp_database.model import UserTeam
 
 from ramp_database.utils import setup_db
 from ramp_database.utils import session_scope
@@ -23,9 +25,15 @@ from ramp_database.testing import add_problems
 from ramp_database.testing import add_users
 from ramp_database.testing import create_test_db
 
+from ramp_database.tools._query import select_event_team_by_user_name
 from ramp_database.tools.team import ask_sign_up_team
 from ramp_database.tools.team import delete_event_team
 from ramp_database.tools.team import sign_up_team
+from ramp_database.tools.team import add_team
+from ramp_database.tools.team import leave_all_teams
+from ramp_database.tools.team import add_team_member
+from ramp_database.tools.team import get_team_members
+from ramp_database.tools.team import respond_team_invite
 
 
 @pytest.fixture
@@ -45,6 +53,56 @@ def session_scope_function(database_connection):
         Model.metadata.drop_all(db)
 
 
+def test_add_team(session_scope_function):
+    session = session_scope_function
+    team_name, username = "new_team", "test_user"
+
+    team = add_team(session, team_name, username)
+
+    session.delete(team)
+    session.commit()
+
+
+def test_add_signup_leave_team(session_scope_function):
+    """A complete test scenario with
+
+    creating a team, signing up to the event and leaving the team
+    """
+    session = session_scope_function
+    team_name, username = "new_team", "test_user"
+    event_name = "iris_test"
+
+    team = add_team(session, team_name, username, is_individual=False)
+    team_id = team.id
+    # A UserTeam entry was created because this is not an individual team
+
+    def query():
+        return session.query(UserTeam).filter_by(team_id=team.id).count()
+
+    assert query() == 1
+
+    # sign up as individual team
+    sign_up_team(session, event_name, username)
+    # and the newly created team
+    sign_up_team(session, event_name, team_name)
+    leave_all_teams(session, event_name, username)
+
+    # After the user leaves the team still exists
+    assert session.query(Team).filter_by(name=team_name).count() == 1
+
+    # However they are no longer part of it in the UserTeam table
+    assert query() == 0
+    # The individual team is then returned for this event
+    event_team = select_event_team_by_user_name(session, event_name, username)
+    assert event_team.team.is_individual is True
+
+    session.delete(team)
+    session.commit()
+
+    # After the team deletion the EventTeam is also deleted
+    assert session.query(EventTeam).filter_by(team_id=team_id).count() == 0
+
+
 def test_ask_sign_up_team(session_scope_function):
     event_name, username = "iris_test", "test_user"
 
@@ -62,11 +120,18 @@ def test_ask_sign_up_team(session_scope_function):
     assert event_team.signup_timestamp.day == current_datetime.day
     assert event_team.approved is False
 
+    assert event_team.is_locked is False
+
 
 def test_sign_up_team(session_scope_function):
     event_name, username = "iris_test", "test_user"
 
-    sign_up_team(session_scope_function, event_name, username)
+    sign_up_team(
+        session_scope_function,
+        event_name,
+        team_name=username,
+        user_name=username,
+    )
     event_team = session_scope_function.query(EventTeam).all()
     assert len(event_team) == 1
     event_team = event_team[0]
@@ -81,6 +146,7 @@ def test_sign_up_team(session_scope_function):
     submission = submission[0]
     assert submission.name == "starting_kit"
     assert submission.event_team == event_team
+    assert submission.user_name == username
     submission_file = submission.files[0]
     assert submission_file.name == "estimator"
     assert submission_file.extension == "py"
@@ -109,3 +175,48 @@ def test_delete_event_team(session_scope_function):
     assert len(user) == 1
     event = session_scope_function.query(Event).filter(Event.name == event_name).all()
     assert len(event) == 1
+
+
+def test_add_team_member(session_scope_function):
+    session = session_scope_function
+    team_name, username = "new_team", "test_user"
+
+    team = add_team(session, team_name, username, is_individual=False)
+
+    assert len(get_team_members(session, team_name, status="accepted")) == 1
+    assert len(get_team_members(session, team_name, status="asked")) == 0
+
+    err = add_team_member(session, team_name, "test_user_2", status="asked")
+    assert err == []
+    assert len(get_team_members(session, team_name, status="accepted")) == 1
+    assert len(get_team_members(session, team_name, status="asked")) == 1
+
+    err = add_team_member(session, username, username)
+    assert err == ["Cannot add members to an individual Team(test_user)"]
+
+    session.delete(team)
+    session.commit()
+
+
+def test_respond_team_invite(session_scope_function):
+    session = session_scope_function
+    team_name, username = "new_team", "test_user"
+
+    team = add_team(session, team_name, username, is_individual=False)
+
+    err = add_team_member(session, team_name, "test_user_2", status="asked")
+
+    assert err == []
+    assert len(get_team_members(session, team_name, status="accepted")) == 1
+    assert len(get_team_members(session, team_name, status="asked")) == 1
+
+    msg = r"Could not find invites for User\(invalid_user\) to Team\(new_team\)"
+    with pytest.raises(ValueError, match=msg):
+        respond_team_invite(session, "invalid_user", team_name, action="accept")
+
+    respond_team_invite(session, "test_user_2", team_name, action="accept")
+    assert len(get_team_members(session, team_name, status="accepted")) == 2
+    assert len(get_team_members(session, team_name, status="asked")) == 0
+
+    session.delete(team)
+    session.commit()


### PR DESCRIPTION
This a follow up on  https://github.com/paris-saclay-cds/ramp-board/pull/545 and adds ramp_database functions to create/join/leave and invite to teams.

Toward https://github.com/paris-saclay-cds/ramp-board/issues/505 

Again it should be backward compatible, as long as those functions are not called (which will be done in a third PR).

TODO: 
 - [ ]  add tests for the few lines not included in test coverage. 