### PR TITLE
CI Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.4
+      - image: circleci/python:3.8.4
         environment:
             # miniconda path install
             MINICONDA_PATH: ~/miniconda

--- a/ci_tools/circle/build_doc.sh
+++ b/ci_tools/circle/build_doc.sh
@@ -8,6 +8,7 @@ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
 chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
 export PATH="$MINICONDA_PATH/bin:$PATH"
 conda update --yes --quiet conda
+conda config --add channels conda-forge
 
 # create the environment
 conda create --yes -n testenv python=3.8


### PR DESCRIPTION
Building of the docs currently fails in  e.g. in https://github.com/paris-saclay-cds/ramp-board/pull/548 with

```python
from . import _bcrypt  # type: ignore
ImportError: libffi.so.7: cannot open shared object file: No such file or directory
```
in CIrcleCI. Trying to update the docker image used and switching to conda-forge channel to fix it.