### PR TITLE
FIX add hyperlink to log when submission failed

### DIFF
--- a/ramp-database/ramp_database/tools/leaderboard.py
+++ b/ramp-database/ramp_database/tools/leaderboard.py
@@ -429,7 +429,7 @@ def get_leaderboard(
                 "submission",
                 "submitted at (UTC)",
                 "state",
-                "wating list",
+                "waiting list",
             ]
         else:
             columns = ["team", "submission", "submitted at (UTC)", "error"]
@@ -447,7 +447,7 @@ def get_leaderboard(
                         pd.Timestamp(sub.submission_timestamp),
                         (
                             sub.state_with_link
-                            if leaderboard_type == "error"
+                            if leaderboard_type == "failed"
                             else sub.state
                         ),
                         (

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -172,7 +172,7 @@ def test_get_leaderboard(session_toy_db):
     )
     assert leaderboard_failed.count("<tr>") == 1
     # check that we have a link to the log of the failed submission
-    assert re.match(r"<a href=/.*/error.txt>", leaderboard_failed)
+    assert re.match(r".*<a href=/.*/error.txt>.*", leaderboard_failed, flags=re.DOTALL)
 
     # the remaining submission should be successful
     leaderboard_public = get_leaderboard(session_toy_db, "public", "iris_test")

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -170,6 +170,10 @@ def test_get_leaderboard(session_toy_db):
         session_toy_db, "failed", "iris_test", "test_user"
     )
     assert leaderboard_failed.count("<tr>") == 1
+    # check that we have a link to the log of the failed submission
+    print(leaderboard_failed)
+    assert False
+    assert "<a href=" in leaderboard_failed
 
     # the remaining submission should be successful
     leaderboard_public = get_leaderboard(session_toy_db, "public", "iris_test")

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 
 import pytest

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -171,9 +171,7 @@ def test_get_leaderboard(session_toy_db):
     )
     assert leaderboard_failed.count("<tr>") == 1
     # check that we have a link to the log of the failed submission
-    print(leaderboard_failed)
-    assert False
-    assert "<a href=" in leaderboard_failed
+    assert re.match("<a href=/.*/error.txt", leaderboard_failed)
 
     # the remaining submission should be successful
     leaderboard_public = get_leaderboard(session_toy_db, "public", "iris_test")

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -172,7 +172,7 @@ def test_get_leaderboard(session_toy_db):
     )
     assert leaderboard_failed.count("<tr>") == 1
     # check that we have a link to the log of the failed submission
-    assert re.match("<a href=/.*/error.txt", leaderboard_failed)
+    assert re.match(r"<a href=/.*/error.txt>", leaderboard_failed)
 
     # the remaining submission should be successful
     leaderboard_public = get_leaderboard(session_toy_db, "public", "iris_test")


### PR DESCRIPTION
closes #575

I suspect this is the source of the error that was introduced in https://github.com/paris-saclay-cds/ramp-board/pull/366

We should probably add a non-regression test that checks that we have a link to a hyperlink with the `failed` leaderboard.