### PR TITLE
up size limit for data in submission_file_types

### DIFF
--- a/ramp-database/ramp_database/testing.py
+++ b/ramp-database/ramp_database/testing.py
@@ -218,7 +218,7 @@ def setup_files_extension_type(session):
     submission_file_types = [
         ("code", True, 10**5),
         ("text", True, 10**5),
-        ("data", False, 10**8),
+        ("data", False, 10**9),
     ]
     for name, is_editable, max_size in submission_file_types:
         add_submission_file_type(session, name, is_editable, max_size)


### PR DESCRIPTION
Up the size limit for data in submission_file_types, mainly to upload bigger weights files for NN (from 100M to 1G)