### PR TITLE
Allow using mean CV score as main score in the leaderboard

### DIFF
--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -11,3 +11,4 @@ Changelog
 ...............
 
 - Switch to fetching starting kit repos via HTTP rather than using git clone to avoid being blocked by Github :pr:`592`.
+- Allow using mean CV score as main score in the leaderboard :pr:`590`

--- a/ramp-database/ramp_database/model/event.py
+++ b/ramp-database/ramp_database/model/event.py
@@ -226,6 +226,14 @@ class Event(Model):
         return self.problem.workflow
 
     @property
+    def leaderboard_score_kind(self):
+        """Whether the main leaderboard score should be bagged or not
+
+        Valid values are "bag" or "mean" (of the CV folds)
+        """
+        return getattr(self.problem.module, "leaderboard_score_kind", "bag")
+
+    @property
     def official_score_type(self):
         """:class:`ramp_database.model.EventScoreType`: The score type for the
         current event."""

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -56,6 +56,145 @@ def session_toy_function(database_connection):
         Model.metadata.drop_all(db)
 
 
+def test_get_leaderboard(session_toy_db):
+    """this test assumes that all the submissions in the database are 'new'"""
+    leaderboard_new = get_leaderboard(session_toy_db, "new", "iris_test")
+    assert leaderboard_new.count("<tr>") == 6
+    leaderboard_new = get_leaderboard(session_toy_db, "new", "iris_test", "test_user")
+    assert leaderboard_new.count("<tr>") == 3
+
+    # run the dispatcher to process the different submissions
+    config = read_config(database_config_template())
+    event_config = read_config(ramp_config_template())
+    dispatcher = Dispatcher(config, event_config, n_workers=-1, hunger_policy="exit")
+    dispatcher.launch()
+    session_toy_db.commit()
+
+    assert get_leaderboard(session_toy_db, "new", "iris_test") is None
+    # the iris dataset has a single submission which is failing
+    leaderboard_failed = get_leaderboard(session_toy_db, "failed", "iris_test")
+    assert leaderboard_failed.count("<tr>") == 2
+    leaderboard_failed = get_leaderboard(
+        session_toy_db, "failed", "iris_test", "test_user"
+    )
+    assert leaderboard_failed.count("<tr>") == 1
+    # check that we have a link to the log of the failed submission
+    assert re.match(r".*<a href=/.*/error.txt>.*", leaderboard_failed, flags=re.DOTALL)
+
+    # the remaining submission should be successful
+    leaderboard_public = get_leaderboard(session_toy_db, "public", "iris_test")
+    assert leaderboard_public.count("<tr>") == 4
+    leaderboard_public = get_leaderboard(
+        session_toy_db, "public", "iris_test", "test_user"
+    )
+    assert leaderboard_public.count("<tr>") == 2
+
+    leaderboard_private = get_leaderboard(session_toy_db, "private", "iris_test")
+    assert leaderboard_private.count("<tr>") == 4
+    leaderboard_private = get_leaderboard(
+        session_toy_db, "private", "iris_test", "test_user"
+    )
+    assert leaderboard_private.count("<tr>") == 2
+
+    # the competition leaderboard will have the best solution for each user
+    competition_public = get_leaderboard(
+        session_toy_db, "public competition", "iris_test"
+    )
+    assert competition_public.count("<tr>") == 2
+    competition_private = get_leaderboard(
+        session_toy_db, "private competition", "iris_test"
+    )
+    assert competition_private.count("<tr>") == 2
+
+    # check the difference between the public and private leaderboard
+    assert leaderboard_private.count("<td>") > leaderboard_public.count("<td>")
+    for private_term in ["bag", "mean", "std", "private"]:
+        assert private_term not in leaderboard_public
+        assert private_term in leaderboard_private
+
+    # check the column name in each leaderboard
+    assert (
+        """<th>submission ID</th>
+      <th>team</th>
+      <th>submission</th>
+      <th>bag public acc</th>
+      <th>mean public acc</th>
+      <th>std public acc</th>
+      <th>bag public error</th>
+      <th>mean public error</th>
+      <th>std public error</th>
+      <th>bag public nll</th>
+      <th>mean public nll</th>
+      <th>std public nll</th>
+      <th>bag public f1_70</th>
+      <th>mean public f1_70</th>
+      <th>std public f1_70</th>
+      <th>bag private acc</th>
+      <th>mean private acc</th>
+      <th>std private acc</th>
+      <th>bag private error</th>
+      <th>mean private error</th>
+      <th>std private error</th>
+      <th>bag private nll</th>
+      <th>mean private nll</th>
+      <th>std private nll</th>
+      <th>bag private f1_70</th>
+      <th>mean private f1_70</th>
+      <th>std private f1_70</th>
+      <th>train time [s]</th>
+      <th>validation time [s]</th>
+      <th>test time [s]</th>
+      <th>max RAM [MB]</th>
+      <th>submitted at (UTC)</th>"""
+        in leaderboard_private
+    )
+    assert (
+        """<th>team</th>
+      <th>submission</th>
+      <th>acc</th>
+      <th>error</th>
+      <th>nll</th>
+      <th>f1_70</th>
+      <th>train time [s]</th>
+      <th>validation time [s]</th>
+      <th>max RAM [MB]</th>
+      <th>submitted at (UTC)</th>"""
+        in leaderboard_public
+    )
+    assert (
+        """<th>team</th>
+      <th>submission</th>
+      <th>id</th>
+      <th>submitted at (UTC)</th>
+      <th>error</th>"""
+        in leaderboard_failed
+    )
+
+    # check the same for the competition leaderboard
+    assert (
+        """<th>rank</th>
+      <th>team</th>
+      <th>submission</th>
+      <th>acc</th>
+      <th>train time [s]</th>
+      <th>validation time [s]</th>
+      <th>submitted at (UTC)</th>"""
+        in competition_public
+    )
+    assert (
+        """<th>rank</th>
+      <th>move</th>
+      <th>team</th>
+      <th>submission</th>
+      <th>acc</th>
+      <th>train time [s]</th>
+      <th>validation time [s]</th>
+      <th>test time [s]</th>
+      <th>submitted at (UTC)</th>"""
+        in competition_private
+    )
+
+
 def test_update_leaderboard_functions(session_toy_function):
     event_name = "iris_test"
     user_name = "test_user"
@@ -205,145 +344,6 @@ def test_get_leaderboard_non_bagged_scores(session_toy_db, monkeypatch):
       <th>acc</th>"""
         )
         in res
-    )
-
-
-def test_get_leaderboard(session_toy_db):
-    """this test assumes that all the submissions in the database are 'new'"""
-    leaderboard_new = get_leaderboard(session_toy_db, "new", "iris_test")
-    assert leaderboard_new.count("<tr>") == 6
-    leaderboard_new = get_leaderboard(session_toy_db, "new", "iris_test", "test_user")
-    assert leaderboard_new.count("<tr>") == 3
-
-    # run the dispatcher to process the different submissions
-    config = read_config(database_config_template())
-    event_config = read_config(ramp_config_template())
-    dispatcher = Dispatcher(config, event_config, n_workers=-1, hunger_policy="exit")
-    dispatcher.launch()
-    session_toy_db.commit()
-
-    assert get_leaderboard(session_toy_db, "new", "iris_test") is None
-    # the iris dataset has a single submission which is failing
-    leaderboard_failed = get_leaderboard(session_toy_db, "failed", "iris_test")
-    assert leaderboard_failed.count("<tr>") == 2
-    leaderboard_failed = get_leaderboard(
-        session_toy_db, "failed", "iris_test", "test_user"
-    )
-    assert leaderboard_failed.count("<tr>") == 1
-    # check that we have a link to the log of the failed submission
-    assert re.match(r".*<a href=/.*/error.txt>.*", leaderboard_failed, flags=re.DOTALL)
-
-    # the remaining submission should be successful
-    leaderboard_public = get_leaderboard(session_toy_db, "public", "iris_test")
-    assert leaderboard_public.count("<tr>") == 4
-    leaderboard_public = get_leaderboard(
-        session_toy_db, "public", "iris_test", "test_user"
-    )
-    assert leaderboard_public.count("<tr>") == 2
-
-    leaderboard_private = get_leaderboard(session_toy_db, "private", "iris_test")
-    assert leaderboard_private.count("<tr>") == 4
-    leaderboard_private = get_leaderboard(
-        session_toy_db, "private", "iris_test", "test_user"
-    )
-    assert leaderboard_private.count("<tr>") == 2
-
-    # the competition leaderboard will have the best solution for each user
-    competition_public = get_leaderboard(
-        session_toy_db, "public competition", "iris_test"
-    )
-    assert competition_public.count("<tr>") == 2
-    competition_private = get_leaderboard(
-        session_toy_db, "private competition", "iris_test"
-    )
-    assert competition_private.count("<tr>") == 2
-
-    # check the difference between the public and private leaderboard
-    assert leaderboard_private.count("<td>") > leaderboard_public.count("<td>")
-    for private_term in ["bag", "mean", "std", "private"]:
-        assert private_term not in leaderboard_public
-        assert private_term in leaderboard_private
-
-    # check the column name in each leaderboard
-    assert (
-        """<th>submission ID</th>
-      <th>team</th>
-      <th>submission</th>
-      <th>bag public acc</th>
-      <th>mean public acc</th>
-      <th>std public acc</th>
-      <th>bag public error</th>
-      <th>mean public error</th>
-      <th>std public error</th>
-      <th>bag public nll</th>
-      <th>mean public nll</th>
-      <th>std public nll</th>
-      <th>bag public f1_70</th>
-      <th>mean public f1_70</th>
-      <th>std public f1_70</th>
-      <th>bag private acc</th>
-      <th>mean private acc</th>
-      <th>std private acc</th>
-      <th>bag private error</th>
-      <th>mean private error</th>
-      <th>std private error</th>
-      <th>bag private nll</th>
-      <th>mean private nll</th>
-      <th>std private nll</th>
-      <th>bag private f1_70</th>
-      <th>mean private f1_70</th>
-      <th>std private f1_70</th>
-      <th>train time [s]</th>
-      <th>validation time [s]</th>
-      <th>test time [s]</th>
-      <th>max RAM [MB]</th>
-      <th>submitted at (UTC)</th>"""
-        in leaderboard_private
-    )
-    assert (
-        """<th>team</th>
-      <th>submission</th>
-      <th>acc</th>
-      <th>error</th>
-      <th>nll</th>
-      <th>f1_70</th>
-      <th>train time [s]</th>
-      <th>validation time [s]</th>
-      <th>max RAM [MB]</th>
-      <th>submitted at (UTC)</th>"""
-        in leaderboard_public
-    )
-    assert (
-        """<th>team</th>
-      <th>submission</th>
-      <th>id</th>
-      <th>submitted at (UTC)</th>
-      <th>error</th>"""
-        in leaderboard_failed
-    )
-
-    # check the same for the competition leaderboard
-    assert (
-        """<th>rank</th>
-      <th>team</th>
-      <th>submission</th>
-      <th>acc</th>
-      <th>train time [s]</th>
-      <th>validation time [s]</th>
-      <th>submitted at (UTC)</th>"""
-        in competition_public
-    )
-    assert (
-        """<th>rank</th>
-      <th>move</th>
-      <th>team</th>
-      <th>submission</th>
-      <th>acc</th>
-      <th>train time [s]</th>
-      <th>validation time [s]</th>
-      <th>test time [s]</th>
-      <th>submitted at (UTC)</th>"""
-        in competition_private
     )
 
 

--- a/ramp-database/ramp_database/tools/tests/test_leaderboard.py
+++ b/ramp-database/ramp_database/tools/tests/test_leaderboard.py
@@ -56,8 +56,10 @@ def session_toy_function(database_connection):
         Model.metadata.drop_all(db)
 
 
-def test_get_leaderboard(session_toy_db):
+def test_get_leaderboard(session_toy_function):
     """this test assumes that all the submissions in the database are 'new'"""
+    session_toy_db = session_toy_function
+
     leaderboard_new = get_leaderboard(session_toy_db, "new", "iris_test")
     assert leaderboard_new.count("<tr>") == 6
     leaderboard_new = get_leaderboard(session_toy_db, "new", "iris_test", "test_user")

--- a/ramp-frontend/ramp_frontend/tests/test_ramp.py
+++ b/ramp-frontend/ramp_frontend/tests/test_ramp.py
@@ -245,27 +245,27 @@ def test_user_event_status(client_session):
 NOW = datetime.datetime.now()
 testtimestamps = [
     (
-        NOW.replace(year=NOW.year + 1),
-        NOW.replace(year=NOW.year + 2),
-        NOW.replace(year=NOW.year + 3),
+        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 3, day=min(NOW.day - 2, 1)),
         b"event-close",
     ),
     (
-        NOW.replace(year=NOW.year - 1),
-        NOW.replace(year=NOW.year + 1),
-        NOW.replace(year=NOW.year + 2),
+        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
         b"event-comp",
     ),
     (
-        NOW.replace(year=NOW.year - 2),
-        NOW.replace(year=NOW.year - 1),
-        NOW.replace(year=NOW.year + 1),
+        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
         b"event-collab",
     ),
     (
-        NOW.replace(year=NOW.year - 3),
-        NOW.replace(year=NOW.year - 2),
-        NOW.replace(year=NOW.year - 1),
+        NOW.replace(year=NOW.year - 3, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
         b"event-close",
     ),
 ]

--- a/ramp-frontend/ramp_frontend/tests/test_ramp.py
+++ b/ramp-frontend/ramp_frontend/tests/test_ramp.py
@@ -245,27 +245,27 @@ def test_user_event_status(client_session):
 NOW = datetime.datetime.now()
 testtimestamps = [
     (
-        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 3, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 1),
+        NOW.replace(year=NOW.year + 2),
+        NOW.replace(year=NOW.year + 3),
         b"event-close",
     ),
     (
-        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 1),
+        NOW.replace(year=NOW.year + 1),
+        NOW.replace(year=NOW.year + 2),
         b"event-comp",
     ),
     (
-        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 2),
+        NOW.replace(year=NOW.year - 1),
+        NOW.replace(year=NOW.year + 1),
         b"event-collab",
     ),
     (
-        NOW.replace(year=NOW.year - 3, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 3),
+        NOW.replace(year=NOW.year - 2),
+        NOW.replace(year=NOW.year - 1),
         b"event-close",
     ),
 ]


### PR DESCRIPTION
This allows to optionally use mean CV score as main score, instead of bagged score, in the leaderboard by setting,
```
leaderboard_score_kind = "mean"
```
in the kit `problem.py`.

The use case is in particular kits that are not able to compute bagged scores such as [stroke_lesions](https://github.com/ramp-kits/stroke_lesions)

cc @frcaud 