### PR TITLE
Fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,4 @@ repos:
     hooks:
     -   id: mypy
         types: [file, python]
-        additional_dependencies: [types-PyYAML, types-click, types-itsdangerous, types-Flask, types-Werkzeug]
+        additional_dependencies: [types-PyYAML, types-click, types-itsdangerous, types-Flask, types-Werkzeug, types-requests]

--- a/ci_tools/circle/build_doc.sh
+++ b/ci_tools/circle/build_doc.sh
@@ -11,7 +11,7 @@ export PATH="/home/circleci/project/miniforge/bin:$PATH"
 conda create --yes -n testenv python=3.8
 conda env update -n testenv -f environment.yml
 source activate testenv
-conda install --yes sphinx=3.5.4 jinja2=3.0.3 sphinx_rtd_theme numpydoc pygraphviz
+conda install --yes sphinx=3.5.4 jinja2=3.0.3 sphinx_rtd_theme numpydoc==1.2.1 pygraphviz
 pip install eralchemy sphinx-click
 
 # Build and install scikit-learn in dev mode

--- a/ci_tools/circle/build_doc.sh
+++ b/ci_tools/circle/build_doc.sh
@@ -4,8 +4,8 @@ set -e
 
 # Install dependencies with miforge
 curl -L -O https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh
-bash Miniforge3-$(uname)-$(uname -m).sh -b -p $MINIFORGE_PATH
-export PATH="$MINIFORGE_PATH/bin:$PATH"
+bash Miniforge3-$(uname)-$(uname -m).sh -b -p /home/circleci/project/miniforge/
+export PATH="/home/circleci/project/miniforge/bin:$PATH"
 
 # create the environment
 conda create --yes -n testenv python=3.8

--- a/doc/whats_new/v0.11.rst
+++ b/doc/whats_new/v0.11.rst
@@ -1,0 +1,13 @@
+.. _changes_0_10:
+
+Version 0.11
+============
+
+Changelog
+---------
+
+
+`ramp-database`
+...............
+
+- Switch to fetching starting kit repos via HTTP rather than using git clone to avoid being blocked by Github :pr:`592`.

--- a/ramp-database/ramp_database/testing.py
+++ b/ramp-database/ramp_database/testing.py
@@ -183,7 +183,7 @@ def setup_ramp_kit_ramp_data(
         shutil.rmtree(problem_kit_path, ignore_errors=True)
 
     ramp_kit_url = (
-        f"https://github.com/ramp-kits/{problem_name}" f"/archive/refs/heads/master.zip"
+        f"https://github.com/ramp-kits/{problem_name}/archive/refs/heads/master.zip"
     )
     _fetch_github_repo(ramp_kit_url, problem_kit_path)
 
@@ -196,7 +196,7 @@ def setup_ramp_kit_ramp_data(
             )
         shutil.rmtree(problem_data_path, ignore_errors=True)
     ramp_kit_url = (
-        f"https://github.com/ramp-data/{problem_name}" f"/archive/refs/heads/master.zip"
+        f"https://github.com/ramp-data/{problem_name}/archive/refs/heads/master.zip"
     )
     _fetch_github_repo(ramp_kit_url, problem_data_path)
 

--- a/ramp-database/ramp_database/testing.py
+++ b/ramp-database/ramp_database/testing.py
@@ -195,10 +195,10 @@ def setup_ramp_kit_ramp_data(
                 'it, you need to set "force=True".'
             )
         shutil.rmtree(problem_data_path, ignore_errors=True)
-    ramp_kit_url = (
+    ramp_data_url = (
         f"https://github.com/ramp-data/{problem_name}/archive/refs/heads/master.zip"
     )
-    _fetch_github_repo(ramp_kit_url, problem_data_path)
+    _fetch_github_repo(ramp_data_url, problem_data_path)
 
     current_directory = os.getcwd()
     os.chdir(problem_data_path)

--- a/ramp-frontend/ramp_frontend/tests/test_ramp.py
+++ b/ramp-frontend/ramp_frontend/tests/test_ramp.py
@@ -245,27 +245,27 @@ def test_user_event_status(client_session):
 NOW = datetime.datetime.now()
 testtimestamps = [
     (
-        NOW.replace(year=NOW.year + 1),
-        NOW.replace(year=NOW.year + 2),
-        NOW.replace(year=NOW.year + 3),
+        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 3, day=min(NOW.day - 2, 1)),
         b"event-close",
     ),
     (
-        NOW.replace(year=NOW.year - 1),
-        NOW.replace(year=NOW.year + 1),
-        NOW.replace(year=NOW.year + 2),
+        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
         b"event-comp",
     ),
     (
-        NOW.replace(year=NOW.year - 2),
-        NOW.replace(year=NOW.year - 1),
-        NOW.replace(year=NOW.year + 1),
+        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
         b"event-collab",
     ),
     (
-        NOW.replace(year=NOW.year - 3),
-        NOW.replace(year=NOW.year - 2),
-        NOW.replace(year=NOW.year - 1),
+        NOW.replace(year=NOW.year - 3, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
         b"event-close",
     ),
 ]

--- a/ramp-frontend/ramp_frontend/tests/test_ramp.py
+++ b/ramp-frontend/ramp_frontend/tests/test_ramp.py
@@ -245,27 +245,27 @@ def test_user_event_status(client_session):
 NOW = datetime.datetime.now()
 testtimestamps = [
     (
-        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 3, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year + 1),
+        NOW.replace(year=NOW.year + 2),
+        NOW.replace(year=NOW.year + 3),
         b"event-close",
     ),
     (
-        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 2, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 1),
+        NOW.replace(year=NOW.year + 1),
+        NOW.replace(year=NOW.year + 2),
         b"event-comp",
     ),
     (
-        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year + 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 2),
+        NOW.replace(year=NOW.year - 1),
+        NOW.replace(year=NOW.year + 1),
         b"event-collab",
     ),
     (
-        NOW.replace(year=NOW.year - 3, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year - 2, day=min(NOW.day - 2, 1)),
-        NOW.replace(year=NOW.year - 1, day=min(NOW.day - 2, 1)),
+        NOW.replace(year=NOW.year - 3),
+        NOW.replace(year=NOW.year - 2),
+        NOW.replace(year=NOW.year - 1),
         b"event-close",
     ),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ Flask-Login==0.5.0
 Flask-Mail==0.9.1
 Flask-SQLAlchemy==2.5.1
 Flask-Wtf==1.0.0
-gitpython
 ipykernel
 jupyter
 numpy


### PR DESCRIPTION
 - Switch to fetching starting kit repos via HTTP rather than using git clone. As far as I can tell all those git clone in CI tests were triggering some github safety blocking the requests, leading the CI to hang.
 - Fix for leap year on 29 february,
```
    NOW.replace(year=NOW.year + 1),
E   ValueError: day is out of range for month 
```
 